### PR TITLE
Feature/support validation  #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It's still in early stage of development, so mostly basic features are being sup
    - [ ] `allOf` support
    - [ ] `discriminator` support
    - [x] `not` *won't be supported*
-   - [ ] validation support (#33)
+   - [x] validation support (#33)
    - [x] NodaTime support opt-in (#32)
 - [x] Multiple responses from one endpoint
 - [ ] Creating endpoints with support for bindings
@@ -56,6 +56,12 @@ It's still in early stage of development, so mostly basic features are being sup
 ```
 - Build project to generate the file
 - Implement interface defined in this file and register your implementation in AspNetCore DI
+- If you want to customize validation for some or all of your models, you have two extension points:
+  - `IGiraffeValidator<'model>` - replaces all generated validation for the `'model` type.
+    Note: doesn't replace the validation for nested complex types (objects, arrays, options).
+    Provide an implementation for them explicitely if you want to replace validation for them too.
+  - `IGiraffeAdditionalValidator<'model>` - adds more validation
+    to either `IGiraffeValidator<'model>` or generated validation
 - May require serializer configuration to support mapping of absent and null values from/to Optionon<_>
 - May require serializer configuration to throw on absent required properties
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ It's still in early stage of development, so mostly basic features are being sup
     Provide an implementation for them explicitely if you want to replace validation for them too.
   - `IGiraffeAdditionalValidator<'model>` - adds more validation
     to either `IGiraffeValidator<'model>` or generated validation
+- Note for people migrating from/to Windows OS: `System.ComponentModel.DataAnnotations.RangeAttribute` used
+  by validation produces a different text representation for Double.*Infinity on Windows: infinity unicode symbol (&#221E;) instead of "Infinity"
 - May require serializer configuration to support mapping of absent and null values from/to Optionon<_>
 - May require serializer configuration to throw on absent required properties
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Example of both:
 ### Generated module name customization
 Defined as parameter `OpenApiModuleName`
 
+### Allowing non-qualified access
+Defined as flag `OpenApiAllowUnqualifiedAccess`
+
 ### NodaTime support
 Enabled by `OpenApiUseNodaTime` flag.
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ It's still in early stage of development, so mostly basic features are being sup
     Provide an implementation for them explicitely if you want to replace validation for them too.
   - `IGiraffeAdditionalValidator<'model>` - adds more validation
     to either `IGiraffeValidator<'model>` or generated validation
-- Note for people migrating from/to Windows OS: `System.ComponentModel.DataAnnotations.RangeAttribute` used
-  by validation produces a different text representation for Double.*Infinity on Windows: infinity unicode symbol (&#221E;) instead of "Infinity"
+- Note for people migrating from/to *nix: `System.ComponentModel.DataAnnotations.RangeAttribute` used
+  by validation produces a different text representation for Double.*Infinity on *nix:
+  "Infinity" instead of infinity unicode symbol (&#221E;)
 - May require serializer configuration to support mapping of absent and null values from/to Optionon<_>
 - May require serializer configuration to throw on absent required properties
 

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -181,7 +181,7 @@ let letDecl recursive name parameters retType expr =
                         false,
                         [],
                         PreXmlDocEmpty,
-                        SynValData.SynValData(None, curriedArgs parameters, None),
+                        SynValData.SynValData(None, curriedArgs [], None),
                         SynPat.LongIdent(longIdentWithDots name, None, None, parameters |> List.map (fun p -> SynPat.Named(SynPat.Wild(r), ident p, false, None, r)) |> Pats, None, r),
                         retType |> Option.map (fun retType -> (SynBindingReturnInfo(retType, r, []))),
                         retType

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -118,14 +118,17 @@ let abstractGetterDfn docs name returnType: SynMemberDefn =
     abstractDfn docs MemberKind.PropertyGet propertyVal name returnType
 
 /// Expression for creating single attribute
-let attr name: SynAttributeList =
+let attrComplex name arg: SynAttributeList =
     { Attributes =
           [ { TypeName = longIdentWithDots name
-              ArgExpr = unitExpr
+              ArgExpr = arg
               Target = None
               AppliesToGetterAndSetter = false
               Range = r } ]
       Range = r }
+/// Expression for creating single attribute
+let attr name: SynAttributeList =
+    attrComplex name unitExpr
 
 /// Type declaration with provided type name and members
 let abstractClassDecl name members =

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -167,7 +167,7 @@ let lambdaFunNextCtxExpr expr =
 
 /// Let declaration
 /// E.g. let {recursive} {name} {parameters}: retType = {expr}
-let letDecl recursive name parameters retType expr =
+let letDeclComplex recursive name parameters retType expr =
     let retType = retType |> Option.map (longIdentWithDots >> SynType.LongIdent)
     SynModuleDecl.Let
         (
@@ -182,7 +182,7 @@ let letDecl recursive name parameters retType expr =
                         [],
                         PreXmlDocEmpty,
                         SynValData.SynValData(None, curriedArgs [], None),
-                        SynPat.LongIdent(longIdentWithDots name, None, None, parameters |> List.map (fun p -> SynPat.Named(SynPat.Wild(r), ident p, false, None, r)) |> Pats, None, r),
+                        SynPat.LongIdent(longIdentWithDots name, None, None, parameters |> Pats, None, r),
                         retType |> Option.map (fun retType -> (SynBindingReturnInfo(retType, r, []))),
                         retType
                             |> Option.map (fun retType -> SynExpr.Typed(expr, retType, r))
@@ -193,6 +193,11 @@ let letDecl recursive name parameters retType expr =
             ],
             r
         )
+/// Let declaration
+/// E.g. let {recursive} {name} {parameters}: retType = {expr}
+let letDecl recursive name parameters retType expr =
+    let parameters = parameters |> List.map (fun p -> SynPat.Named(SynPat.Wild(r), ident p, false, None, r))
+    letDeclComplex recursive name parameters retType expr
 
 /// Let declaration for Giraffe HttpHandler with specified name and body expression
 /// E.g.:

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -146,10 +146,10 @@ let abstractClassDecl name members =
 
 /// Module declaration with splitting incoming string by '.'
 /// and with [<RequireQualifiedAccess>] attribute
-let moduleDecl xml name decls =
+let moduleDecl requireQualifiedAccess xml name decls =
     let moduleName = longIdent name
 
-    let attrib = [ attr "RequireQualifiedAccess" ]
+    let attrib = [ if requireQualifiedAccess then attr "RequireQualifiedAccess" ]
     SynModuleOrNamespace.SynModuleOrNamespace
         (moduleName, false, SynModuleOrNamespaceKind.NamedModule, decls, xml, attrib, None, r)
 

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -262,10 +262,16 @@ let letExpr name parameters body next =
 let letGetServiceDecl next =
     letExpr "service" [] getServiceCall next
 
+let private ifThenElseExpr cond ifTrue ifFalse =
+    SynExpr.IfThenElse(cond, ifTrue, ifFalse, DebugPointForBinding.NoDebugPointAtInvisibleBinding, false, r, r)
 /// If-Then-Else expression
 /// if {cond} then {ifTrue} else {ifFalse}
 let ifElseExpr cond ifTrue ifFalse =
-    SynExpr.IfThenElse(cond, ifTrue, Some ifFalse, DebugPointForBinding.NoDebugPointAtInvisibleBinding, false, r, r)
+    ifThenElseExpr cond ifTrue (Some ifFalse)
+/// If-Then-Else expression
+/// if {cond} then {ifTrue} else {ifFalse}
+let ifExpr cond ifTrue =
+    ifThenElseExpr cond ifTrue None
 
 /// LetBang! expression:
 /// let! {ident} = {expr} in {next}

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -64,6 +64,9 @@ let emptyMethodVal =
 /// Expression for named pattern {name}
 let synPat name =
     SynPat.Named(SynPat.Wild(r), ident name, false, None, r)
+/// Expression for typed named pattern ({name}: {synType})
+let synPatTyped name synType =
+    SynPat.Typed(synPat name, synType, r)
 
 /// Expression for long idented pattern
 /// {pat} {name}
@@ -423,7 +426,9 @@ let simplePat name = SynSimplePat.Id(ident name,None,false,false,false,r)
 
 let simplePats pats = SynSimplePats.SimplePats(pats, r)
 
-let singleTypedPat name synType = [SynSimplePat.Typed(simplePat name, synType, r)] |> simplePats 
+let simpleTypedPat name synType = SynSimplePat.Typed(simplePat name, synType, r)
+
+let singleTypedPat name synType = simplePats [simpleTypedPat name synType] 
 
 let singleSimplePat name = simplePats [simplePat name]
 
@@ -493,8 +498,13 @@ let field name fieldType =
     SynField.Field([], false, Some(ident name), fieldType, false, PreXmlDoc.Empty, None, r)
    
 /// Tuple pattern (for arg list or matching) 
+let tuplePatComplex args =
+    SynPat.Paren(SynPat.Tuple(false, args, r), r)
+/// Tuple pattern (for arg list or matching) 
 let tuplePat args =
-    SynPat.Paren(SynPat.Tuple(false, args |> List.map (fun v -> SynPat.Named(SynPat.Wild(r), ident v, false, None, r)), r), r)
+   args
+   |> List.map (fun v -> SynPat.Named(SynPat.Wild(r), ident v, false, None, r))
+   |> tuplePatComplex
 
 /// Expression for implementing any member kind in class
 let implDefn memberKind isOverride name args expr =

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -290,6 +290,11 @@ let taskBuilder body =
 /// return! {expr}
 let returnBang expr =
     SynExpr.YieldOrReturnFrom((false, true), expr, r)
+
+/// Expression for YieldFrom (yield!) with continuation:
+/// yield! {expr}
+let yieldBang expr =
+    SynExpr.YieldOrReturnFrom((true, true), expr, r)
     
 /// Expression for Return (return) with continuation:
 /// return {expr}

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -423,6 +423,10 @@ let simplePat name = SynSimplePat.Id(ident name,None,false,false,false,r)
 
 let simplePats pats = SynSimplePats.SimplePats(pats, r)
 
+let singleTypedPat name synType = [SynSimplePat.Typed(simplePat name, synType, r)] |> simplePats 
+
+let singleSimplePat name = simplePats [simplePat name]
+
 let lambda pats body =
     SynExpr.Lambda(false, false, pats, body, r) |> paren
 

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -604,6 +604,7 @@ let simpleValueMatching value cases =
     matchExpr value clauses
 let inline (^|>) a b = app (appI (identExpr "op_PipeRight") a) b
 let inline (^>>) a b = paren (app (appI (identExpr "op_ComposeRight") a) b)
+let inline (^=) a b = app (appI (identExpr "op_Equals") a) b
 
 let setStatusCodeExpr code =
     app (identExpr "setStatusCode") (intExpr code)

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -517,8 +517,8 @@ let nodaTypes =
 
 /// Expression for field in records
 /// {name}: {fieldType}
-let field name fieldType =
-    SynField.Field([], false, Some(ident name), fieldType, false, PreXmlDoc.Empty, None, r)
+let field attributes name fieldType =
+    SynField.Field(attributes, false, Some(ident name), fieldType, false, PreXmlDoc.Empty, None, r)
    
 /// Tuple pattern (for arg list or matching) 
 let tuplePatComplex args =

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -612,9 +612,12 @@ let simpleValueMatching value cases =
                     SynPat.LongIdent(longIdentWithDots v, None, None, [SynPat.Named(SynPat.Wild(r), ident into, false, None, r)] |> Pats, None, r) ^=> res
             )
     matchExpr value clauses
-let inline (^|>) a b = app (appI (identExpr "op_PipeRight") a) b
-let inline (^>>) a b = paren (app (appI (identExpr "op_ComposeRight") a) b)
-let inline (^=) a b = app (appI (identExpr "op_Equals") a) b
+
+
+let inline appBinaryOpExpr op a b = app(appI (identExpr op) a) b
+let inline (^|>) a b = appBinaryOpExpr "op_PipeRight" a b
+let inline (^>>) a b = appBinaryOpExpr "op_ComposeRight" a b |> paren
+let inline (^=) a b = appBinaryOpExpr "op_Equals" a b
 
 let setStatusCodeExpr code =
     app (identExpr "setStatusCode") (intExpr code)

--- a/src/GiraffeGenerator.Core/AST.fs
+++ b/src/GiraffeGenerator.Core/AST.fs
@@ -630,6 +630,12 @@ let simpleValueMatching value cases =
     matchExpr value clauses
 
 
+let tryGetSingleExpression expressions =
+    let len = List.length expressions
+    if len = 0 then None
+    elif len = 1 then Some expressions.Head
+    else seqExprs expressions |> Some
+
 let inline appBinaryOpExpr op a b = app(appI (identExpr op) a) b
 let inline (^|>) a b = appBinaryOpExpr "op_PipeRight" a b
 let inline (^>>) a b = appBinaryOpExpr "op_ComposeRight" a b |> paren

--- a/src/GiraffeGenerator.Core/ASTExt.fs
+++ b/src/GiraffeGenerator.Core/ASTExt.fs
@@ -3,18 +3,29 @@
 open AST
 
 let _id = identExpr "id"
+let _not = identExpr "not"
 let seqChooseId = app (longIdentExpr "Seq.choose") _id
+
+module Array =
+    let mapExpr = longIdentExpr "Array.map" |> app
+    let lengthExpr = longIdentExpr "Array.length"
+    let headExpr = longIdentExpr "Array.head"
+    
 module Seq =
     let collectExpr = longIdentExpr "Seq.collect" |> app
     let chooseExpr = longIdentExpr "Seq.choose" |> app
     let mapExpr = longIdentExpr "Seq.map" |> app
     let filterExpr = longIdentExpr "Seq.filter" |> app
     let reduceExpr reducer initial = app (app (longIdentExpr "Seq.reduce") reducer) initial
+    let containsExpr = longIdentExpr "Seq.contains" |> app
 
 module Option =
     let bindExpr = longIdentExpr "Option.bind" |> app
     let mapExpr = longIdentExpr "Option.map" |> app
+    let map2Expr f a b = app (app (app (longIdentExpr "Option.map2") f) a) b
+    let orElseExpr = longIdentExpr "Option.orElse" |> app
     let defaultValueExpr = longIdentExpr "Option.defaultValue" |> app
+    let ofObjExpr = longIdentExpr "Option.ofObj" |> app
     let isSomeExpr = longIdentExpr "Option.isSome"
     
 module Result =

--- a/src/GiraffeGenerator.Core/ASTExt.fs
+++ b/src/GiraffeGenerator.Core/ASTExt.fs
@@ -21,3 +21,7 @@ module Result =
     let mapExpr = longIdentExpr "Result.map" |> app
     let bindExpr = longIdentExpr "Result.bind" |> app
     let mapErrorExpr = longIdentExpr "Result.mapError" |> app
+
+module String =
+    let concatExprComplex delimiterExpr = app (longIdentExpr "String.concat") delimiterExpr
+    let concatExpr delimiter = concatExprComplex (strExpr delimiter)

--- a/src/GiraffeGenerator.Core/ASTExt.fs
+++ b/src/GiraffeGenerator.Core/ASTExt.fs
@@ -10,8 +10,8 @@ module Seq =
     let mapExpr = longIdentExpr "Seq.map" |> app
     let filterExpr = longIdentExpr "Seq.filter" |> app
     let reduceExpr reducer initial = app (app (longIdentExpr "Seq.reduce") reducer) initial
+
 module Option =
-    
     let bindExpr = longIdentExpr "Option.bind" |> app
     let mapExpr = longIdentExpr "Option.map" |> app
     let defaultValueExpr = longIdentExpr "Option.defaultValue" |> app

--- a/src/GiraffeGenerator.Core/CodeGen.fs
+++ b/src/GiraffeGenerator.Core/CodeGen.fs
@@ -162,12 +162,12 @@ let rec generateBinds bound leftToBind generateFinal =
     if List.length leftToBind > 0 then
         identExpr bound
         ^|> Result.bindExpr
-            ^ lambda ([simplePat bound] |> simplePats)
+            ^ lambda (singleSimplePat bound)
                 ^ generateBinds leftToBind.Head leftToBind.Tail generateFinal
     else
         identExpr bound
             ^|> Result.mapExpr
-                ^ lambda ([simplePat bound] |> simplePats) ^ generateFinal()
+                ^ lambda (singleSimplePat bound) ^ generateFinal()
 
 /// generates mapping from all non-body parameters to combined record
 /// (combined records are described in module generation)

--- a/src/GiraffeGenerator.Core/CodeGen.fs
+++ b/src/GiraffeGenerator.Core/CodeGen.fs
@@ -207,6 +207,7 @@ let giraffeAst (api: Api) =
           openDecl "Giraffe"
           openDecl "System.Threading.Tasks"
           openDecl "Microsoft.AspNetCore.Http"
+          openDecl "Microsoft.Extensions.DependencyInjection"
           
           let temporarySchemasForBindingBeforeDefaultsAppliance =
               [ for path in api.Paths do

--- a/src/GiraffeGenerator.Core/CodeGen.fs
+++ b/src/GiraffeGenerator.Core/CodeGen.fs
@@ -249,16 +249,8 @@ let giraffeAst (api: Api) =
                 yield! temporarySchemasForBindingBeforeDefaultsAppliance |> Seq.map ^ fun v -> { Kind = v.Generated; Name = v.GeneratedName; Docs = None; DefaultValue = None }
                 for path in api.Paths do
                     for method in path.Methods do
-                        
-                        let allParameterSchemas =
-                            let body = method.BodyParameters |> Option.map (Seq.map snd)
-                            let nonBody = method.OtherParameters |> Option.map (Map.toSeq >> Seq.map snd)
-                            Option.map2 Seq.append nonBody body
-                            |> Option.orElse body
-                            |> Option.orElse nonBody  
-                        if allParameterSchemas.IsSome then
-                            for schema in allParameterSchemas.Value do
-                                schema
+                        for schema in method.AllParameters do
+                            schema
                                 
                         if hasMultipleNonBodyParameters method then
                             let name = requestCommonInputTypeName method

--- a/src/GiraffeGenerator.Core/CodeGen.fs
+++ b/src/GiraffeGenerator.Core/CodeGen.fs
@@ -200,7 +200,8 @@ let giraffeAst (api: Api) =
     moduleDecl
         (xml api.Docs)
         moduleName
-        [ openDecl "FSharp.Control.Tasks.V2.ContextInsensitive"
+        [ openDecl "System.ComponentModel.DataAnnotations"
+          openDecl "FSharp.Control.Tasks.V2.ContextInsensitive"
           openDecl "Giraffe"
           openDecl "System.Threading.Tasks"
           openDecl "Microsoft.AspNetCore.Http"

--- a/src/GiraffeGenerator.Core/CodeGen.fs
+++ b/src/GiraffeGenerator.Core/CodeGen.fs
@@ -275,6 +275,7 @@ let giraffeAst (api: Api) =
     let moduleName = Configuration.value.ModuleName |> Option.defaultValue api.Name
     
     moduleDecl
+        (not Configuration.value.AllowUnqualifiedAccess)
         (xml api.Docs)
         moduleName
         [ openDecl "System.ComponentModel.DataAnnotations"

--- a/src/GiraffeGenerator.Core/CodeGen.fs
+++ b/src/GiraffeGenerator.Core/CodeGen.fs
@@ -559,7 +559,12 @@ let giraffeAst (api: Api) =
                                                     | v -> failwithf "Content type %A is not supported" v
                                                     |> longIdentExpr
                                                 // add type parameter to the chosen method
-                                                let typeApp = typeApp expr [bodyInputForBindingMapping |> Option.map (fun v -> v.GeneratedName) |> Option.defaultValue bodySchema.Name |> synType]
+                                                let typeApp =
+                                                    let generatedName =
+                                                        bodyInputForBindingMapping
+                                                        |> Option.map (fun v -> v.GeneratedName)
+                                                    let bindingType = extractBodyBindingSynType generatedName bodySchema.Name bodySchema.Kind
+                                                    typeApp expr [bindingType]
                                                 // and call it without arguments
                                                 let call = app typeApp (tupleExpr [])
                                                 // and let-bind it and wrap binding into Result<_,_> 

--- a/src/GiraffeGenerator.Core/CodeGen.fs
+++ b/src/GiraffeGenerator.Core/CodeGen.fs
@@ -257,7 +257,10 @@ let giraffeAst (api: Api) =
                             generateCombinedRecordTypeDefnFor method.OtherParameters.Value name]
 
           if not allSchemas.IsEmpty then
-              yield! [
+              yield! [                    
+                 if validationErrorsPossible then
+                    types (CodeGenValidation.generateModuleLevelDeclarations api)
+
                  types (extractRecords allSchemas)
 
                  if validationErrorsPossible || nonValidationErrorsPossible then

--- a/src/GiraffeGenerator.Core/CodeGen.fs
+++ b/src/GiraffeGenerator.Core/CodeGen.fs
@@ -220,7 +220,7 @@ let extractRecords (schemas: TypeSchema list) =
                 objectKind.Properties
                 |> List.map (fun (fieldName, fieldKind, def) ->
                     extractSynType (fieldName, fieldKind)
-                    |> field fieldName)
+                    |> field (CodeGenValidation.getValidationAttributesForProperty fieldKind) fieldName)
 
             // add name and fields for later
             if not ^ recordsDict.ContainsKey name then

--- a/src/GiraffeGenerator.Core/CodeGen.fs
+++ b/src/GiraffeGenerator.Core/CodeGen.fs
@@ -1,8 +1,10 @@
 module CodeGen
 
+open System.Collections.Generic
 open System.Globalization
 open AST
 open ASTExt
+open FSharp.Compiler.XmlDoc
 open OpenApi
 open OpenApiToAstTypesMatchingAndConversion
 open Fantomas
@@ -194,6 +196,79 @@ let generateInputsCombination combinedRecordPropertyToOriginalValue synt (schema
             (identExpr "v")
     let onlyNames = bindings |> List.map snd
     generateBinds onlyNames.Head onlyNames.Tail finalGenerator
+
+
+/// extract record definitions from
+let extractRecords (schemas: TypeSchema list) =
+    // store name and fields of records here
+    let recordsDict =
+        Dictionary<string, SynField list * Docs option>()
+    // store name and cases of records here
+    let duDict =
+        Dictionary<string, (string * SynType * PreXmlDoc) list * Docs option>()
+    
+    let rec extractSynType (name: string, kind: TypeKind) =
+        match kind with
+        | Prim primType -> primTypeMatch primType
+        | BuiltIn builtIn -> synType builtIn
+        | Array (innerType, _, _) -> arrayOf (extractSynType (getOwnName innerType (fun () -> name), innerType))
+        | Option innerType -> optionOf (extractSynType (getOwnName innerType (fun () -> name), innerType))
+        | Object objectKind ->
+            let name = getOwnName kind ^ fun _ -> name
+            // extract field types
+            let fields =
+                objectKind.Properties
+                |> List.map (fun (fieldName, fieldKind, def) ->
+                    extractSynType (fieldName, fieldKind)
+                    |> field fieldName)
+
+            // add name and fields for later
+            if not ^ recordsDict.ContainsKey name then
+                recordsDict.Add(name, (fields, objectKind.Docs))
+
+            // return SynType with record name
+            synType name
+        | DU du ->
+            let cases =
+                du.Cases
+                |> List.mapi
+                   (
+                       fun idx case ->
+                           let name = case.CaseName |> Option.defaultWith (fun _ -> sprintf "Case%d" (idx + 1))
+                           let subtypeName = getOwnName case.Kind (fun _ -> name + "CaseValue")
+                           name,
+                           extractSynType(subtypeName, case.Kind),
+                           xml case.Docs
+                   )
+            if cases.Length > 0 && not ^ duDict.ContainsKey du.Name then
+                duDict.Add(du.Name, (cases, du.Docs))
+            synType name
+        | NoType -> failwith "Field without types are not supported for record schemas"
+
+    // iterate through schemas
+    // records will be stored in dictionary as a side effect
+    for schema in schemas do
+        extractSynType (schema.Name, schema.Kind)
+        |> ignore
+    
+    // create final DU expressions
+    let dus =    
+        duDict
+        |> Seq.map
+        ^ fun (KeyValue(name, (cases, docs))) ->
+            discriminatedUnion (xml docs) name cases
+
+    // create final record expressions
+    let records =
+        recordsDict
+        |> Seq.map
+        ^ fun (KeyValue (name, (fields, docs))) ->
+            let xmlDocs = xml docs
+            record xmlDocs name fields
+    
+    dus
+    |> Seq.append records
+    |> Seq.toList
 
 /// Creating whole module AST for Giraffe webapp
 let giraffeAst (api: Api) =    

--- a/src/GiraffeGenerator.Core/CodeGenErrorsDU.fs
+++ b/src/GiraffeGenerator.Core/CodeGenErrorsDU.fs
@@ -138,7 +138,7 @@ let private outerErrToStringDecl =
                  (String.concatExpr "\\n\\n")
                  (
                      app // Seq.map (recCall (level + 1))
-                         (app (longIdentExpr "Seq.map") (paren(app (identExpr outerErrToStringName) (paren(nextLevel)))))
+                         (Seq.mapExpr (paren(app (identExpr outerErrToStringName) (paren(nextLevel)))))
                          (identExpr err)
                      |> paren
                  )

--- a/src/GiraffeGenerator.Core/CodeGenErrorsDU.fs
+++ b/src/GiraffeGenerator.Core/CodeGenErrorsDU.fs
@@ -1,5 +1,6 @@
 ﻿module CodeGenErrorsDU
 open AST
+open ASTExt
 open FSharp.Compiler.SyntaxTree
 open OpenApi
     
@@ -99,7 +100,7 @@ let private innerErrToStringDecl =
             sprintfExpr "%sMultiple errors:\\n%s"
             ^ [identExpr sepVar
                app
-                (app (longIdentExpr "String.concat") (strExpr "\\n"))
+                (String.concatExpr "\\n")
                 (
                     app // Seq.map (recCall (level + 1))
                         (app (longIdentExpr "Seq.map") (paren(app (identExpr innerErrToStringName) (paren(nextLevel)))))
@@ -134,7 +135,7 @@ let private outerErrToStringDecl =
              sprintfExpr "%sMultiple binding errors:\\n%s"
              ^ [identExpr sepVar
                 app
-                 (app (longIdentExpr "String.concat") (strExpr "\\n\\n"))
+                 (String.concatExpr "\\n\\n")
                  (
                      app // Seq.map (recCall (level + 1))
                          (app (longIdentExpr "Seq.map") (paren(app (identExpr outerErrToStringName) (paren(nextLevel)))))

--- a/src/GiraffeGenerator.Core/CodeGenErrorsDU.fs
+++ b/src/GiraffeGenerator.Core/CodeGenErrorsDU.fs
@@ -18,7 +18,7 @@ let private errInnerType =
               {
                   CaseName = Some errInnerGiraffeBinding
                   Docs = summary "Giraffe returned a Result.Error from tryBindXXX"
-                  Kind = Prim <| PrimTypeKind.String StringFormat.String
+                  Kind = Prim <| PrimTypeKind.String (StringFormat.String None)
               }
               {
                   CaseName = Some errInnerFormatterBindingExn
@@ -28,7 +28,7 @@ let private errInnerType =
               {
                   CaseName = Some errInnerCombined
                   Docs = summary "Multiple errors occurred in one location"
-                  Kind = TypeKind.Array (DU { Name = errInnerTypeName; Docs = None; Cases = [] }, None)
+                  Kind = TypeKind.Array (DU { Name = errInnerTypeName; Docs = None; Cases = [] }, None, None)
               }
           ]
   }
@@ -61,7 +61,7 @@ let private errOuterType =
               {
                   CaseName = Some errOuterCombined
                   Docs = summary "Multiple locations errors"
-                  Kind = TypeKind.Array (DU { Name = errOuterTypeName; Docs = None; Cases = [] }, None)
+                  Kind = TypeKind.Array (DU { Name = errOuterTypeName; Docs = None; Cases = [] }, None, None)
               }
           ]
   }

--- a/src/GiraffeGenerator.Core/CodeGenValidation.fs
+++ b/src/GiraffeGenerator.Core/CodeGenValidation.fs
@@ -5,6 +5,7 @@ open CodeGenValidation_Types
 open CodeGenValidation_Types.Enumeration
 open CodeGenValidation_TypeGeneration
 open CodeGenValidation_TypeGeneration.ExtensionPoints
+open CodeGenValidation_InstanceGeneration
 open CodeGenValidation_LogicGeneration
 
 /// gets all validation attributes to be used in API
@@ -47,3 +48,5 @@ let generateModuleLevelDeclarations api =
 /// {resultExpr} |> Result.bind (bindValidation (isValueValid [|{attribute instances for this value}|]) ctx {location})
 /// for any other kind of value
 let bindValidationIntoResult = bindValidationIntoResult
+
+let getValidationAttributesForProperty = getValidationAttributesForProperty

--- a/src/GiraffeGenerator.Core/CodeGenValidation.fs
+++ b/src/GiraffeGenerator.Core/CodeGenValidation.fs
@@ -5,6 +5,7 @@ open CodeGenValidation_Types
 open CodeGenValidation_Types.Enumeration
 open CodeGenValidation_TypeGeneration
 open CodeGenValidation_TypeGeneration.ExtensionPoints
+open CodeGenValidation_LogicGeneration
 
 /// gets all validation attributes to be used in API
 let private decideWhichValidationIsBeingUsed api =
@@ -22,13 +23,27 @@ let generateModuleLevelDeclarations api =
         |> Seq.distinctBy identifyCustomValidationAttributeType
         |> Seq.sortBy string
         |> Seq.toArray
+    let hasGeneratedValidationRules = usedValidationTypes.Length > 0
     [
         for validationType in usedValidationTypes do
             let attrOption = generateAttributeDefinitionFor validationType
             if attrOption.IsSome then
                 attrOption.Value
         generateValidationReplacerInterface()
-        let hasGeneratedValidationRules = usedValidationTypes.Length > 0
         if hasGeneratedValidationRules then
             generateValidationAugmenterInterface()
+    ], [
+        let replacerInterface = validationReplacerInterface
+        let augmenterInterface =
+            Some validationAugmenterInterface
+            |> Option.filter (fun _ -> hasGeneratedValidationRules)
+        yield! generateValidationBinder api replacerInterface augmenterInterface
     ]
+
+
+/// Applies validation to the resultExpr:
+/// {resultExpr} |> Result.bind (bindValidation isObjectValid ctx {location})
+/// for objects and DUs or
+/// {resultExpr} |> Result.bind (bindValidation (isValueValid [|{attribute instances for this value}|]) ctx {location})
+/// for any other kind of value
+let bindValidationIntoResult = bindValidationIntoResult

--- a/src/GiraffeGenerator.Core/CodeGenValidation.fs
+++ b/src/GiraffeGenerator.Core/CodeGenValidation.fs
@@ -1,0 +1,29 @@
+﻿module CodeGenValidation
+
+open OpenApi
+open CodeGenValidation_Types
+open CodeGenValidation_Types.Enumeration
+open CodeGenValidation_TypeGeneration
+
+/// gets all validation attributes to be used in API
+let private decideWhichValidationIsBeingUsed api =
+    seq {
+        for path in api.Paths do
+            for method in path.Methods do
+                for parameter in method.AllParameters do
+                    yield! enumerateKindValidation true parameter.Kind 
+    }
+    
+let generateModuleLevelDeclarations api =
+    let usedValidation = decideWhichValidationIsBeingUsed api |> Seq.toArray
+    let usedValidationTypes =
+        usedValidation
+        |> Seq.distinctBy identifyCustomValidationAttributeType
+        |> Seq.sortBy string
+        |> Seq.toArray
+    [
+        for validationType in usedValidationTypes do
+            let attrOption = generateAttributeDefinitionFor validationType
+            if attrOption.IsSome then
+                attrOption.Value
+    ]

--- a/src/GiraffeGenerator.Core/CodeGenValidation.fs
+++ b/src/GiraffeGenerator.Core/CodeGenValidation.fs
@@ -4,6 +4,7 @@ open OpenApi
 open CodeGenValidation_Types
 open CodeGenValidation_Types.Enumeration
 open CodeGenValidation_TypeGeneration
+open CodeGenValidation_TypeGeneration.ExtensionPoints
 
 /// gets all validation attributes to be used in API
 let private decideWhichValidationIsBeingUsed api =
@@ -26,4 +27,8 @@ let generateModuleLevelDeclarations api =
             let attrOption = generateAttributeDefinitionFor validationType
             if attrOption.IsSome then
                 attrOption.Value
+        generateValidationReplacerInterface()
+        let hasGeneratedValidationRules = usedValidationTypes.Length > 0
+        if hasGeneratedValidationRules then
+            generateValidationAugmenterInterface()
     ]

--- a/src/GiraffeGenerator.Core/CodeGenValidation_InstanceGeneration.fs
+++ b/src/GiraffeGenerator.Core/CodeGenValidation_InstanceGeneration.fs
@@ -96,3 +96,12 @@ let getValidationAttributeConstructionForKind expr kind =
         let attrConstruction = List.map snd expressions
         if attrConstruction.IsEmpty then None
         else (isSpecialCased, SynExpr.ArrayOrList(true, attrConstruction, r)) |> Some
+
+let getValidationAttributesForProperty kind =
+    [
+        for attr in enumeratePropertyValidation false kind do
+            let def = getAttributeUsageDefinitionForAttribute attr
+            if def.IsSome then
+                let attrName, args = def.Value 
+                attrComplex attrName (if args.IsEmpty then unitExpr else tupleComplexExpr args)
+    ]

--- a/src/GiraffeGenerator.Core/CodeGenValidation_InstanceGeneration.fs
+++ b/src/GiraffeGenerator.Core/CodeGenValidation_InstanceGeneration.fs
@@ -1,0 +1,98 @@
+﻿module CodeGenValidation_InstanceGeneration
+
+open CodeGenValidation_Types
+open CodeGenValidation_Types.Enumeration
+open AST
+open FSharp.Compiler.SyntaxTree
+
+// get the name and argument expression list for the attribute passed
+let getTypeMin (typeName: string) =
+    let suffix =
+        if typeName.EndsWith("Double") then
+            ".NegativeInfinity"
+        else ".MinValue"
+    typeName + suffix |> longIdentExpr
+let getTypeMax (typeName: string) =
+    let suffix =
+        if typeName.EndsWith("Double") then
+            ".PositiveInfinity"
+        else ".MaxValue"
+    typeName + suffix |> longIdentExpr
+let private rangeToExpressions typeName valueToConst r =
+    let valueToExpr = valueToConst >> constExpr
+    match r with
+    | Min min -> [valueToExpr min; getTypeMax typeName]
+    | Max max -> [getTypeMin typeName; valueToExpr max]
+    | Both (min, max) -> [valueToExpr min; valueToExpr max]
+let private getAttributeUsageDefinitionForBuiltInAttribute =
+    function
+    | Required -> "Required", []
+    | FloatRange r -> "Range", rangeToExpressions "System.Double" SynConst.Double r
+    | IntRange r -> "Range", rangeToExpressions "System.Int32" SynConst.Int32 r
+    | MaxLength len -> "MaxLength", [intExpr len]
+    | MinLength len -> "MinLength", [intExpr len]
+let private getEnumAttributeUsageDefinition =
+    let convertArgs toConst values =
+        values
+        |> Seq.map toConst
+        |> Seq.map constExpr
+        |> Seq.toList
+    function
+    | IntEnum values -> "IntEnumValues", convertArgs SynConst.Int32 values
+    | LongEnum values -> "LongEnumValues", convertArgs SynConst.Int64 values
+    | FloatEnum values -> "FloatEnumValues", convertArgs SynConst.Double values
+    | StringEnum values -> "StringEnumValues", convertArgs (fun v -> SynConst.String(v, r)) values
+let private getMultipleOfAttributeUsageDefinition =
+    let convertArg toConst value =
+        [toConst value |> constExpr]
+    function
+    | IntMultiple divisor -> "IntMultipleOf", convertArg SynConst.Int32 divisor
+    | LongMultiple divisor -> "LongMultipleOf", convertArg SynConst.Int64 divisor
+let private getAttributeUsageDefinitionForSpecialCasedAttribute expr =
+    function
+    | BuiltInAttribute _
+    | CustomAttribute _ -> None
+    | SpecialCasedCustomValidationAttribute specialCased ->
+        match specialCased with
+        | UniqueItems ->
+            let exprLength =
+                SynExpr.DotGet(expr, r, longIdentWithDots "Length", r)
+            let set =
+                app (identExpr "Set") (expr) |> paren
+            let setCount =
+                SynExpr.DotGet(set, r, longIdentWithDots "Count", r)
+            Some ("UniqueItems", [exprLength ^= setCount])
+let private getAttributeUsageDefinitionForCustomAttribute =
+    function
+    | LongRange r -> "LongRange", rangeToExpressions "System.Int64" SynConst.Int64 r
+    | RegexPattern pattern -> "RegexPattern", [strExpr pattern]
+    | EnumAttribute enum -> getEnumAttributeUsageDefinition enum
+    | MultipleOf target -> getMultipleOfAttributeUsageDefinition target
+let rec private getAttributeUsageDefinitionForAttribute attr =
+    match attr with
+    | BuiltInAttribute builtIn -> getAttributeUsageDefinitionForBuiltInAttribute builtIn |> Some
+    | CustomAttribute custom -> getAttributeUsageDefinitionForCustomAttribute custom |> Some
+    | SpecialCasedCustomValidationAttribute _ -> None
+
+/// generates an array of isSpecialCased * array expr of attributeTypeName(attributeConstructorParameters) for a kind
+let getValidationAttributeConstructionForKind expr kind =
+    [
+        for attr in enumerateKindValidation false kind do
+            let commonDefinition =
+                getAttributeUsageDefinitionForAttribute attr
+                |> Option.map (fun x -> false, x)
+            let specialCasedDefinition =
+                getAttributeUsageDefinitionForSpecialCasedAttribute expr attr
+                |> Option.map (fun x -> true, x)
+            let definition = Option.orElse specialCasedDefinition commonDefinition
+            
+            if definition.IsSome then
+                let isSpecialCased, (attrName, args) = definition.Value
+                let arg = tupleComplexExpr args
+                isSpecialCased, app (identExpr (attrName + "Attribute")) arg
+    ]
+    |> List.groupBy fst
+    |> List.choose ^ fun (isSpecialCased, expressions) ->
+        let attrConstruction = List.map snd expressions
+        if attrConstruction.IsEmpty then None
+        else (isSpecialCased, SynExpr.ArrayOrList(true, attrConstruction, r)) |> Some

--- a/src/GiraffeGenerator.Core/CodeGenValidation_LogicGeneration.fs
+++ b/src/GiraffeGenerator.Core/CodeGenValidation_LogicGeneration.fs
@@ -1,0 +1,472 @@
+﻿/// # Design notes
+/// We decided to use built-in DataAnnotations validation. This applies several restrictions:
+/// 1. Attributes may only be applied to properties on type level.
+///    This means no straightforward way to validate array items and option values (i.e. values inside a monad).
+///    Considered solutions:
+/// 
+///    I. Generation of attributes like ArrayItemRegexPatternAttribute
+///    Rejected because of really messy codegen for nested monads:
+///    each combination of nesting and rule would require a separate attribute like
+///    OptionValueArrayItemArrayItemMinLengthAttribute and OptionValueArrayItemArrayItemRegexPatternAttribute.
+///
+///    II. Generation of an attribute to treat some of monadic property validation attributes as a monad value attributes
+///    Rejected because:
+///    1. DataAnnotations.Validator provides no way for an attribute to observe another attributes.
+///       May be worked around with reflection, but generation of reflection at design-time seems extremely ugly
+///    2. DataAnnotations.Validator provides no way for an attribute to interfere the validation process,
+///       e.g. we can't prevent it from trying to apply the attributes for monad's value to the monad itself.
+///       This may be worked around with generation of the special attributes but this would fail for the same reasons as III.
+/// 
+///    III. Generation of non deeply nested validation only
+///    E.g. generate OptionValueRegexPattern but throw instead of generating OptionValueArrayItemRegexPatternAttribute.
+///    Failed because
+///    1. We need to know the type parameter of a monad to perform validation.
+///    2. The most realistic case for monad value validation is a validation of some user type.
+///       This means that attribute type definition depends on the types to which attribute is applied.
+///       F# won't compile such recursion for some reason. Tested both `module rec` and `type..and` approaches.
+///       Sample: https://github.com/bessgeor/GiraffeGenerator/commit/29702b0497e643f99dd24bfc3c6ab8ccb769ec7c
+/// 
+/// 2. DataAnnotations.Validator treats records, record properties and other values as a separate concepts.
+///    This means we should differentiate them too (different codegen)
+///
+/// 4. DataAnnotations.Validator can't perform recursive validation.
+///    E.g. given the model
+///    type NestedObject =
+///        { [<Range(2,3)>]
+///          int2Or3: int }
+///    type WhateverPostBodyJson =
+///        { [<Required>]
+///          NestedObject: NestedObject }
+///    instance { NestedObject = { int2Or3 = 100500 } } would be treated as valid.
+///    This means we should generate recursion ourselves.
+///
+/// Because we should generate traversal of object graph anyways,
+/// we could solve 1. by including monad values validation into the traversal process.
+///
+/// ## Other constraints:
+/// - We should provide an extension point for user to customize validation
+/// - We should allow user to handle validation errors like any other contract violation.
+///   Which means we should bind validation into Result<'model, ArgumentLocationedError
+///
+/// ## The design
+/// The core of the validation is the static object graph traversal function (validate).
+/// It accepts a boxed value and type-check matches it against
+/// 1. Parameter types from every source including body - they would come to the validation in the first place
+/// 2. Every record type nested in the parameters. This allows to reduce copy-paste codegen in case of type re-use and to reduce the maximum indentation
+/// It returns an System.ComponentModel.DataAnnotations.ValidationResult array
+/// It recurse on any TypeKind.Object property, array item or option value
+/// It applies Validator.TryValidateObject to any record it finds.
+///     This may be reconsidered to generation of validation for each property.
+///     Considerations should include the validation caching as the property validation is probably the most realistic scenario for users, thus it allocates a lot.
+///     Also, Validator.TryValidateObject ignores the property path given - custom validation may include the full path assembling.
+///     Also, this place is the only real dependency on DataAnnotations for the internal code.
+/// It applies special-cased validation (the one which accepts isValid flag ignoring the real value to avoid cross-dependency of attributes and user types) to any value requiring it.
+/// It applies other validation defined for the value if it is not the direct value of a property (in which case Validator.TryValidateObject would carry out this validation).
+/// It traverses Option.Value if Option.isSome.
+/// It traverses arrays via for..to loop to provide index information for the property path.
+/// It traverses record properties of non-primitive types.
+///
+/// There are some helper functions:
+/// - validateInner
+///   accepts the value and a validation function for it. Checks if there are implementations of extension point interfaces registered in the DI.
+///   If IGiraffeValidator<'value> is registered, applies it's validation - this is an option for user to opt-out generated validation.
+///   Otherwise the function from parameters is applied.
+///   Anyways, if there is IGiraffeAdditionalValidator<'value> registered in the DI, it's output is appended to the results. This provides an opt-in validation extension point.
+/// - isObjectValid
+///   Curried wrapper for Validator.TryValidateObject to be passed as validation function to validateInner function.
+/// - isObjectValid
+///   Curried wrapper for Validator.TryValidateValue to be passed as validation function to validateInner function.
+///   Accepts attribute array as the first parameter to be partially applied before passing.
+/// - withValue/withMemberAndValue
+///   Helpers for forking a ValidationContext objects.
+/// - bindValidation
+///   Interface function for validation. Binder for Result<'model, ArgumentLocationedError> calling the validate function.
+module CodeGenValidation_LogicGeneration
+
+open FSharp.Compiler.SyntaxTree
+open OpenApi
+open OpenApiToAstTypesMatchingAndConversion
+open CodeGenErrorsDU
+open CodeGenValidation_InstanceGeneration
+open AST
+open ASTExt 
+
+
+/// Helper for ReferenceEquals(x, null).
+/// FSharp thinks that interface declared in it may not be null
+/// (including the instance that may be returned from IServiceProvider.GetService which is obviously false)
+/// I don't like to mark the types with [<AllowNullLiteral>] in this case
+/// because nullability is an interface of IServiceProvider.GetService which has nothing to do with the type itself.
+/// So use System.Object.ReferenceEquals(value, null) instead of FSharp's isNull   
+let private isNullRef x = tupleComplexExpr [identExpr x; SynExpr.Null r] |> app (longIdentExpr "System.Object.ReferenceEquals")
+
+let isObjectValid = "isObjectValid"
+/// let isObjectValid boxed errors validationContext = Validator.TryValidateObject(boxed, validationContext, errors, true)
+let private isObjectValidDeclaration =
+    letDecl false "isObjectValid" ["boxed"; "errors"; "validationContext"] None
+        (app
+            (longIdentExpr "Validator.TryValidateObject")
+            (tupleComplexExpr [identExpr "boxed"; identExpr "validationContext"; identExpr "errors"; constExpr (SynConst.Bool true)]))
+
+let isValueValid = "isValueValid"
+/// let isValueValid validationAttributes boxed errors validationContext = Validator.TryValidateValue(boxed, validationContext, errors, validationAttributes)
+let private isValueValidDeclaration =
+    letDecl false "isValueValid" ["validationAttributes"; "boxed"; "errors"; "validationContext"] None
+        (app
+            (longIdentExpr "Validator.TryValidateValue")
+            (tupleExpr ["boxed"; "validationContext"; "errors"; "validationAttributes"]))
+
+
+/// let validateInner isValid (ctx: HttpContext) validationContext value =
+///     let customValidator =
+///         ctx.RequestServices.GetService<IGiraffeValidator<'model>>()
+/// 
+///     let errs =
+///         if System.Object.ReferenceEquals(customValidator, null) then
+///             let errs = System.Collections.Generic.List()
+///             if isValid errs validationContext then Array.empty else errs |> Seq.toArray
+///         else
+///             customValidator.Validate(value, validationContext)
+/// 
+///     let customAugmentingValidator =
+///         ctx.RequestServices.GetService<IGiraffeAdditionalValidator<'model>>()
+/// 
+///     if System.Object.ReferenceEquals(customAugmentingValidator, null) then
+///         errs
+///     else
+///         customAugmentingValidator.Validate(value, validationContext)
+///         |> Array.append errs 
+let private validateInnerDeclaration replacerInterface augmenterInterface =
+    // declaration of the binder function
+    let generic = SynType.Var(Typar(ident "model", NoStaticReq, false), r)
+    let args =
+        [ synPat "isValid"
+          tuplePatComplex [synPatTyped "ctx" (synType "HttpContext")]
+          synPat "validationContext"
+          tuplePatComplex [synPatTyped "value" generic] ]
+    let declare = letDeclComplex false "validateInner" args None
+
+    // let binding for custom validator interface instance
+    let letCustomValidator = letGetAnyServiceDecl "customValidator" false (genericType false replacerInterface [generic])
+    
+    /// binding of errors either from built-in validation or from validation replacer service provided by the user
+    let letErrs1 =
+        letExpr "errs" []
+            (ifElseExpr (isNullRef "customValidator")
+                (letExpr "errs" [] (app (longIdentExpr "System.Collections.Generic.List") (tupleExpr []))
+                    (
+                        ifElseExpr (curriedCall "isValid" ["value"; "errs"; "validationContext"]) (longIdentExpr "Array.empty")
+                            (identExpr "errs" ^|> longIdentExpr "Seq.toArray")
+                    ))
+                (app (longIdentExpr "customValidator.Validate") (tupleExpr ["value"; "validationContext"])))
+    
+    /// append errors from validation augmentation to the errors returned from the previous step
+    /// if the validation augmentation is possible and defined for the validated type by the user
+    let letErrs2 =
+        augmenterInterface |> Option.map ^ fun augmenter ->
+            letExpr "errs" [] (
+                    letGetAnyServiceDecl "customAugmentingValidator" false (genericType false augmenter [generic])
+                        (
+                            ifElseExpr (isNullRef "customAugmentingValidator")
+                                (identExpr "errs")
+                                (app (longIdentExpr "customAugmentingValidator.Validate") (tupleExpr ["value"; "validationContext"])
+                                 ^|> app (longIdentExpr "Array.append") (identExpr "errs"))
+                        )
+               )
+        |> Option.defaultValue id
+    
+    declare
+    ^ letCustomValidator
+    ^ letErrs1
+    ^ letErrs2
+    ^ identExpr "errs"
+
+/// let withValue (validationContext: ValidationContext) value =
+///     let ctx = ValidationContext(box value, validationContext.Items)
+///     ctx.InitializeServiceProvider(fun t -> validationContext.GetService t)
+///     ctx.MemberName <- null
+///     ctx
+let withValueDeclaration =
+    let args = [tuplePatComplex [synPatTyped "validationContext" (synType "ValidationContext")]; synPat "value"]
+    let declare = letDeclComplex false "withValue" args None
+    let letCtx =
+        letExpr "ctx" []
+            (tupleComplexExpr
+                [(identExpr "value"); (longIdentExpr "validationContext.Items")]
+                |> app (identExpr "ValidationContext"))
+    let actions =
+        seqExprs [
+            app (longIdentExpr "ctx.InitializeServiceProvider") (lambda (simplePats [ simplePat "t" ]) (app (longIdentExpr "validationContext.GetService") (identExpr "t")))
+            SynExpr.LongIdentSet(longIdentWithDots "ctx.MemberName", SynExpr.Null r, r)
+            identExpr "ctx"
+        ]
+    declare
+    ^ letCtx
+    ^ actions
+
+/// let withMemberAndValue validationContext name value =
+///     let ctx = withValue validationContext value
+///     // this is the original behaviour of Validator: it would ignore MemberName in context when object is validated
+///     // so keep it for consistency
+///     ctx.MemberName <- name
+///     ctx
+let withMemberAndValueDeclaration =
+    let args = [
+        tuplePatComplex [synPatTyped "validationContext" (synType "ValidationContext")]
+        synPat "name"
+        synPat "value"
+    ]
+    let declare = letDeclComplex false "withMemberAndValue" args None
+    let letCtx =
+        letExpr "ctx" [] (curriedCall "withValue" [ "validationContext"; "value" ])
+    let actions =
+        seqExprs [
+            // this is the original behaviour of Validator: it would ignore MemberName in context when object is validated
+            // so keep it for consistency
+            SynExpr.LongIdentSet(longIdentWithDots "ctx.MemberName", identExpr "name", r)
+            identExpr "ctx"
+        ]
+    declare
+    ^ letCtx
+    ^ actions
+    
+let validationBinder = "bindValidation"
+/// let bindValidation isValid (ctx: HttpContext) location (value: 'model) =
+///     let validationContext =
+///         ValidationContext(value, ctx.RequestServices, ctx.Items)
+/// 
+///     let errs = validate isValid ctx validationContext
+///     if Array.length errs > 0 then
+///         errs |> ArgumentValidationError |> location |> Error
+///     else Ok value
+let private binderDeclaration =
+    let generic = SynType.Var(Typar(ident "model", NoStaticReq, false), r)
+    let args =
+        [ tuplePatComplex [synPatTyped "ctx" (synType "HttpContext")]
+          synPat "location"
+          tuplePatComplex [synPatTyped "value" generic] ]
+    let letDecl = letDeclComplex false validationBinder args None
+    
+    // validation context which contains the value, service provider and a property bag (Yay! We are like AspNetCore MVC here)
+    let letValidationContext =
+        letExpr "validationContext" []
+            (app
+                 (identExpr "ValidationContext")
+                 (tupleComplexExpr [identExpr "value"; longIdentExpr "ctx.RequestServices"; longIdentExpr "ctx.Items"]))
+    let letErrs = letExpr "errs" [] (curriedCall "validate" ["ctx"; "validationContext"])
+    
+    let returnExpr =
+        ifElseExpr ((identExpr "errs" ^|> Array.lengthExpr |> paren) ^= intExpr 0)
+            (app (identExpr "Ok") (identExpr "value"))
+            (identExpr "errs"
+             ^|> identExpr errInnerValidationError
+             ^|> identExpr "location"
+             ^|> identExpr "Error")
+    
+    letDecl
+    ^ letValidationContext
+    ^ letErrs
+    ^ returnExpr
+
+
+/// let rec validate isPassedValueValid ctx (validationContext: ValidationContext) =
+///     [|
+///         match validationContext.ObjectInstance with
+///         | :? (TestValidationPostBodyJson array) as value ->
+///             yield! validateInner isPassedValueValid ctx validationContext value 
+///             for value in value do
+///                 yield! validate isObjectValid ctx (withValue validationContext value)
+///         | :? (TestValidationPostBodyJson) as value ->
+///             yield! validateInner isPassedValueValid ctx validationContext value
+///             yield! validate isObjectValid ctx (withMemberAndValue validationContext "nestedValidationObjectOfIntGTE2" value.nestedValidationObjectOfIntGTE2)
+///             if value.nestedValidationOptionOfIntGTE2.IsSome then
+///                 let newValidationCtx = withMemberAndValue validationContext "nestedValidationOptionOfIntGTE2.Value" value.nestedValidationOptionOfIntGTE2.Value
+///                 yield! validateInner (isValueValid [| RangeAttribute(2, System.Int32.MaxValue) |]) ctx newValidationCtx value.nestedValidationOptionOfIntGTE2.Value
+///             if value.deeplyNestedValidation.IsSome then
+///                 for value in value.deeplyNestedValidation.Value do
+///                     for value in value do
+///                         yield! validate isObjectValid ctx (withMemberAndValue validationContext "deeplyNestedValidation.Value.[i].[j]" value)
+///         | :? (nestedValidationObjectOfIntGTE2) as value ->
+///             yield! validateInner isPassedValueValid ctx validationContext value
+///         | :? (deeplyNestedValidation) as value ->
+///             yield! validateInner isPassedValueValid ctx (withValue validationContext value) value
+///         | :? (PostTestValidationPath) as value ->
+///             yield! validateInner isPassedValueValid ctx validationContext value
+///         | :? (PostTestValidationQuery) as value ->
+///             yield! validateInner isPassedValueValid ctx validationContext value
+///         | v -> failwithf "Unknown type came to validation: %A" (v.GetType())
+///     |]
+module private ValidateDeclaration =
+    let private validateInner isValid vCtx value =
+        let fName =
+            if Option.isSome value then
+                "validateInner"
+            else "validate"
+        let f = identExpr fName
+        [
+            yield f
+            if Option.isSome value then
+                yield isValid
+            yield identExpr "ctx"
+            yield vCtx
+            if Option.isSome value then
+                yield Option.get value
+        ]
+        |> List.reduce (app)
+        |> yieldBang
+
+    let private validationContext = identExpr "validationContext"
+
+    let private letNewCtx innerCtx body =
+        body |> Option.map ^ fun body ->
+            letExpr "validationContext" [] innerCtx body
+
+    let private validatePassed value = validateInner (identExpr isObjectValid) validationContext (Some value)
+
+    let private validateValue value attrs =
+        validateInner (app (identExpr isValueValid) attrs |> paren) validationContext (Some value)
+
+    let private validateObj vCtx = validateInner (identExpr isObjectValid) vCtx None
+
+    let private withMemberAndValueComplex memberNameExpr value =
+        app (app (app (identExpr "withMemberAndValue") validationContext) memberNameExpr) value
+
+    let private withMemberAndValue memberName value =
+        withMemberAndValueComplex (strExpr memberName) value
+
+    let private arrayIteratorVars =
+        [|0..10|]
+        |> Seq.map char
+        |> Seq.map ((+)'i')
+        |> Seq.map string
+        |> Seq.map (fun i -> ident i, identExpr i)
+        |> Seq.toArray
+
+    let private getArrayIteratorOrFail i =
+        let i = i - 1 // i is always incremented before access
+        if i >= arrayIteratorVars.Length then
+            failwithf "Nested arrays of %d deepness aren't supported" i
+        else arrayIteratorVars.[i]
+
+    let private generateInnerValidation recurse memberName kind arrayNesting isInPropertyContext newCtx innerExpr =
+        match kind with
+        | TypeKind.Object _ -> validateObj validationContext |> Some |> letNewCtx newCtx
+        // Option itself may not be validated so don't generate a context for it
+        // It should be special-cased because `new ValidationContext(None)` would throw ArgumentNullException
+        | TypeKind.Option _ -> recurse memberName arrayNesting isInPropertyContext innerExpr kind
+        | _ -> recurse memberName arrayNesting isInPropertyContext innerExpr kind |> letNewCtx newCtx
+
+    let private generateSpecialCasedValidation isInPropertyContext expr kind = [
+        for isSpecialCased, ownValidationAttributes in getValidationAttributeConstructionForKind expr kind do
+            if (not isSpecialCased) && (not isInPropertyContext) then // properties would be validated against non special case attributes by validateObject 
+                validateValue expr ownValidationAttributes |> Some
+            if isSpecialCased then 
+                validateValue expr ownValidationAttributes |> Some
+    ]
+
+    let rec private generateValidateCaseBody memberName arrayNesting isInPropertyContext expr kind: SynExpr option =
+        let expressions =
+            [
+                match kind with
+                | TypeKind.Object o ->
+                    validatePassed expr |> Some
+                    for (name, kind, _) in o.Properties do
+                        let innerExpr = SynExpr.DotGet(expr, r, longIdentWithDots name, r)
+                        let newCtx = withMemberAndValue name innerExpr
+                        generateInnerValidation generateValidateCaseBody (Some name) kind arrayNesting true newCtx innerExpr
+
+                | TypeKind.Array (inner, _, _) ->
+                    yield! generateSpecialCasedValidation isInPropertyContext expr kind
+                    
+                    let arrayNesting = arrayNesting + 1
+                    let iDef, iExpr = getArrayIteratorOrFail arrayNesting
+                    
+                    let innerExpr = SynExpr.DotIndexedGet(expr, [SynIndexerArg.One(iExpr, false, r)], r, r)
+                    let newCtx = withMemberAndValueComplex (sprintfExpr "%s[%d]" [longIdentExpr "validationContext.MemberName"; iExpr] |> paren) innerExpr
+                    
+                    generateInnerValidation generateValidateCaseBody None inner arrayNesting false newCtx innerExpr
+                    |> Option.map ^ fun innerBody ->
+                        let outerBound = appBinaryOpExpr "op_Subtraction" (SynExpr.DotGet(expr, r, longIdentWithDots "Length", r)) (intExpr 1)
+                        SynExpr.For(DebugPointAtFor.Yes r, iDef, intExpr 0, true, outerBound, innerBody, r)
+
+                | TypeKind.Option inner ->
+                    let innerExpr = SynExpr.DotGet(expr, r, longIdentWithDots "Value", r)
+                    let memberNameExpr =
+                        if memberName.IsSome then
+                            strExpr (memberName.Value + ".Value")
+                        else sprintfExpr "%s.Value" [longIdentExpr "validationContext.MemberName"] |> paren
+                    let newCtx = withMemberAndValueComplex memberNameExpr innerExpr
+                    generateInnerValidation generateValidateCaseBody None inner arrayNesting false newCtx innerExpr
+                    |> Option.map ^ fun innerBody -> 
+                        ifExpr (expr ^|> longIdentExpr "Option.isSome") innerBody
+
+                | _ ->
+                    yield! generateSpecialCasedValidation isInPropertyContext expr kind
+            ] |> List.choose id
+        tryGetSingleExpression expressions
+
+    let private generateValidateCases expr outerName kind =
+        let rec gatherObjects isOutermost outerName kind =
+            let inline gatherObjects o k = gatherObjects false o k
+            match kind with
+            | TypeKind.Object o ->
+                [
+                    // all topmost types should be matched whenever they are objects or not. 
+                    if not isOutermost then
+                        extractResponseSynType outerName kind, kind
+                    for name, kind, _ in o.Properties do
+                        yield! gatherObjects (Some name) kind
+                ]
+            | TypeKind.Array (kind, _, _)
+            | TypeKind.Option kind -> gatherObjects outerName kind
+            | TypeKind.DU _ -> failwith "DU validation is not supported"
+            | TypeKind.Prim _
+            | TypeKind.BuiltIn _
+            | TypeKind.NoType -> []
+        let generateCase synType kind =
+            let isInPropertyContext = false
+            synType, generateValidateCaseBody None 0 isInPropertyContext expr kind
+        [
+            generateCase (extractResponseSynType outerName kind) kind
+            for synType, obj in gatherObjects true outerName kind do
+                generateCase synType obj
+        ]
+
+    let validateDeclaration api =
+        matchExpr "instance" [
+            for path in api.Paths do
+                for method in path.Methods do
+                    for schema in method.AllParameters do
+                        for kind, body in generateValidateCases (identExpr "value") (Some schema.Name) schema.Kind do
+                            clause
+                                (SynPat.Named(SynPat.IsInst(kind, r), ident "value", false, None, r))
+                                (Option.defaultValue unitExpr body)
+            clause (synPat "v") (app (app (identExpr "failwithf") (strExpr "Unknown type came to validation: %A")) (app (longIdentExpr "v.GetType") unitExpr |> paren))
+        ]
+        |> List.singleton
+        |> fun x -> SynExpr.ArrayOrList(true, x, r)
+        |> letExpr "instance" [] (longIdentExpr "validationContext.ObjectInstance")
+        |> letDeclComplex true "validate"
+               [ synPat "ctx"
+                 tuplePatComplex [synPatTyped "validationContext" (synType "ValidationContext")]
+               ] None
+    
+let generateValidationBinder api replacerInterface augmenterInterface =
+    seq {
+        isObjectValidDeclaration
+        isValueValidDeclaration
+        validateInnerDeclaration replacerInterface augmenterInterface
+        withValueDeclaration
+        withMemberAndValueDeclaration
+        ValidateDeclaration.validateDeclaration api
+        binderDeclaration
+    }
+
+/// Applies validation to the resultExpr:
+/// {resultExpr} |> Result.bind (bindValidation isObjectValid ctx {location})
+/// for objects and DUs or
+/// {resultExpr} |> Result.bind (bindValidation (isValueValid [|{attribute instances for this value}|]) ctx {location})
+/// for any other kind of value
+let bindValidationIntoResult location resultExpr =
+    let validationBinder = identExpr validationBinder
+    resultExpr ^|> Result.bindExpr (app (app validationBinder (identExpr "ctx")) (identExpr location) |> paren)

--- a/src/GiraffeGenerator.Core/CodeGenValidation_TypeGeneration.fs
+++ b/src/GiraffeGenerator.Core/CodeGenValidation_TypeGeneration.fs
@@ -1,0 +1,203 @@
+﻿module CodeGenValidation_TypeGeneration
+
+open FSharp.Compiler.SyntaxTree
+open CodeGenValidation_Types
+open AST
+open ASTExt
+
+/// codegen custom attributes for
+/// - multiplyOf
+/// - enum
+/// - uniqueItems
+/// - pattern (built-in one doesn't follow the OpenAPI spec: not ECMAScript and always tries to match the whole string)
+/// - minValue and maxValue for Int64 (as a Range attribute)
+/// Example:
+(*
+type IntEnumAttribute([<System.ParamArray>]values: int array) =
+    inherit ValidationAttribute(sprintf "must be a one of %s" (String.concat ", " (Seq.map string values)))
+        override this.FormatErrorMessage name = sprintf "The field %s %s" name base.ErrorMessage
+        override _.IsValid(value: obj) =
+            let value = value :?> int
+            values |> Array.contains value
+
+type StringEnumAttribute([<System.ParamArray>]values: string array) =
+    inherit ValidationAttribute(sprintf "must be a one of %s" (String.concat ", " values))
+        override this.FormatErrorMessage name = sprintf "The field %s %s" name base.ErrorMessage
+        override _.IsValid(value: obj) =
+            let value = value :?> string
+            values |> Array.contains value
+
+type IntMultiplyOfAttribute(divisor: int) =
+    inherit ValidationAttribute(sprintf "must be a multiply of %d" divisor)
+        override this.FormatErrorMessage name = sprintf "The field %s %s" name base.ErrorMessage
+        override _.IsValid(value: obj) =
+            let value = value :?> int
+            value % divisor = 0
+
+// special case, as described in the according DU
+type UniqueItemsAttribute(isValid) =
+    inherit ValidationAttribute("must contain only unique values")
+        override this.FormatErrorMessage name = sprintf "The field %s %s" name base.ErrorMessage
+        override _.IsValid(value: obj) = isValid
+*)
+/// generates custom ValidationAttribute. Body should assume single parameter "value" of type obj
+let private generateAttributeDefinitionASTComplex additionalMembers (attributeName, pats, messageExpr, bodyExpr) =
+    let componentInfo =
+        SynComponentInfo.ComponentInfo
+            ([], [], [], longIdent attributeName, xmlEmpty, false, None, r)
+
+    let implicitCtor = SynMemberDefn.ImplicitCtor(None, [], simplePats pats, None, r)
+
+    let inheritance =
+        SynMemberDefn.ImplicitInherit(synType "ValidationAttribute", messageExpr, None, r)
+    
+    let methodOverride =
+        implDefn MemberKind.Member true "IsValid" ["value"] bodyExpr
+    
+    let messageOverride =
+        implDefn MemberKind.Member true "FormatErrorMessage" ["name"]
+            (sprintfExpr "The field %s %s." [identExpr "name"; longIdentExpr "base.ErrorMessageString"])
+    
+    let members =
+        [
+            implicitCtor
+            inheritance
+            yield! additionalMembers
+            messageOverride
+            methodOverride
+        ]
+    
+    let objModel =
+        SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.TyconUnspecified, members, r)
+
+    TypeDefn(componentInfo, objModel, [], r)
+
+let private rangeBody name synType =
+    let pats = [simpleTypedPat "min" synType; simpleTypedPat "max" synType]
+    let min = identExpr "min"
+    let max = identExpr "max"
+    let value = identExpr "value"
+    let lte = appBinaryOpExpr "op_LessThanOrEqual"
+    let checkMin = lte min value
+    let checkMax = lte value max
+    let body = appBinaryOpExpr "op_BooleanAnd" checkMin checkMax
+    let message = "must be between %d and %d", [min; max]
+    name + "RangeAttribute", pats, message, body        
+
+let private generateSpecialCasedAttributeBody attrName attrMessage =
+    let pats = [simpleTypedPat "isValid" boolType]
+    let message = strExpr attrMessage
+    attrName, pats, message, identExpr "isValid"
+
+let private generateCustomAttributeValidationBodyForTypedValue value =
+    match value with
+    | LongRange _ -> [], rangeBody "Long" int64Type
+    | RegexPattern _ ->
+        let pattern = simpleTypedPat "pattern" (stringType)
+        let pats = [pattern]
+        let pattern = identExpr "pattern"
+        let regexMember =
+            [
+                pattern
+                appBinaryOpExpr
+                    "op_BitwiseOr"
+                    (longIdentExpr "System.Text.RegularExpressions.RegexOptions.ECMAScript")
+                    (longIdentExpr "System.Text.RegularExpressions.RegexOptions.Compiled")
+            ]
+            |> tupleComplexExpr
+            |> app (longIdentExpr "System.Text.RegularExpressions.Regex")
+        let regexMember =
+            SynMemberDefn.LetBindings
+                ([
+                    SynBinding.Binding
+                        (None,
+                         SynBindingKind.NormalBinding,
+                         false,
+                         false,
+                         [],
+                         xmlEmpty,
+                         SynValData (None, SynValInfo([], SynArgInfo([], false, None)), None),
+                         synPat "regex",
+                         None,
+                         regexMember,
+                         r,
+                         DebugPointForBinding.DebugPointAtBinding r)
+                 ], false, false, r)
+        let body = app (longIdentExpr "regex.IsMatch") (identExpr "value")
+        let message = "must match the regular expression '%s'", [pattern]
+        [regexMember], ("RegexPattern", pats, message, body)
+    | MultipleOf target ->
+        let name, argType, zero =
+            match target with
+            | IntMultiple _ -> "Int", intType, intExpr 0
+            | LongMultiple _ -> "Long", int64Type, constExpr(SynConst.Int64 0L)
+        let pats = [simpleTypedPat "divisor" argType]
+        let divisor = identExpr "divisor"
+        let value = identExpr "value"
+        let body = appBinaryOpExpr "op_Modulus" value divisor ^= zero
+        let name = sprintf "%sMultipleOfAttribute" name
+        let message = "must be a multiple of %d", [divisor]
+        [], (name, pats, message, body)
+    | EnumAttribute target ->
+        let name, argType, mapper =
+            match target with
+            | IntEnum _ -> "Int", intType, identExpr "string"
+            | LongEnum _ -> "Long", int64Type, identExpr "string"
+            | FloatEnum _ -> "Float", doubleType, identExpr "string"
+            | StringEnum _ -> "String", stringType, _id
+        let pats = [SynSimplePat.Attrib(simpleTypedPat "values" (genericType true "array" [argType]), [attr "System.ParamArray"], r)]
+        let values = identExpr "values"
+        let value = identExpr "value"
+        let body = values ^|> app (longIdentExpr "Array.contains") value
+        let name = sprintf "%sEnumValuesAttribute" name
+        let message = "must be a one of ['%s']", [values ^|> Seq.mapExpr mapper ^|> String.concatExpr "', '" |> paren]
+        [], (name, pats, message, body)
+    
+let private messageToExpr (pattern, args) =
+    if args |> List.tryHead |> Option.isSome then
+        sprintfExpr pattern args |> paren
+    else strExpr pattern
+
+let private generateAttributeForSpecialCasedValidationType value =
+    match value with
+    | UniqueItems ->
+        generateSpecialCasedAttributeBody "UniqueItemsAttribute" "must contain only unique items"
+    |> generateAttributeDefinitionASTComplex []
+
+let private generateAttributeForCustomValidationType value =
+    let additionalMembers, (name, pats, message, rawBody) = generateCustomAttributeValidationBodyForTypedValue value
+    let message = messageToExpr message
+    match value with
+    | LongRange _ ->
+        let body = letExpr "value" [] (SynExpr.Downcast(identExpr "value", int64Type, r)) rawBody
+        name, pats, message, body
+    | RegexPattern _ ->
+        let body = letExpr "value" [] (SynExpr.Downcast(identExpr "value", stringType, r)) rawBody
+        name, pats, message, body
+    | MultipleOf target ->
+        let argType =
+            match target with
+            | IntMultiple _ -> intType
+            | LongMultiple _ -> int64Type
+        let body = letExpr "value" [] (SynExpr.Downcast(identExpr "value", argType, r)) rawBody
+        name, pats, message, body
+    | EnumAttribute target ->
+        let argType =
+            match target with
+            | IntEnum _ -> intType
+            | LongEnum _ -> int64Type
+            | FloatEnum _ -> doubleType
+            | StringEnum _ -> stringType
+        let body = letExpr "value" [] (SynExpr.Downcast(identExpr "value", argType, r)) rawBody
+        name, pats, message, body
+    |> generateAttributeDefinitionASTComplex additionalMembers
+
+let generateAttributeDefinitionFor value =
+    match value with
+    | CustomAttribute custom ->
+        generateAttributeForCustomValidationType custom
+        |> Some
+    | SpecialCasedCustomValidationAttribute specialCased ->
+        generateAttributeForSpecialCasedValidationType specialCased
+        |> Some
+    | BuiltInAttribute _ -> None

--- a/src/GiraffeGenerator.Core/CodeGenValidation_Types.fs
+++ b/src/GiraffeGenerator.Core/CodeGenValidation_Types.fs
@@ -167,3 +167,27 @@ module rec Enumeration =
             | TypeKind.BuiltIn _ -> ()
         }
         |> Seq.choose id
+
+/// gets a unique identifier of a custom attribute type ignoring any parameters for a type's instance
+/// basically converts DU case value to a bitflag
+/// 0 indicates a non-custom type which needs no generation
+let rec identifyCustomValidationAttributeType value =
+    match value with
+    | BuiltInAttribute _ -> 0
+    | SpecialCasedCustomValidationAttribute specialCased ->
+        match specialCased with
+        | UniqueItems _ -> 1
+    | CustomAttribute custom ->
+        match custom with
+        | LongRange _ -> 2
+        | RegexPattern _ -> 4
+        | MultipleOf target ->
+            match target with
+            | IntMultiple _ -> 8
+            | LongMultiple _ -> 16
+        | EnumAttribute enum ->
+            match enum with
+            | IntEnum _ -> 32
+            | LongEnum _ -> 64
+            | FloatEnum _ -> 128
+            | StringEnum _ -> 256

--- a/src/GiraffeGenerator.Core/CodeGenValidation_Types.fs
+++ b/src/GiraffeGenerator.Core/CodeGenValidation_Types.fs
@@ -1,0 +1,90 @@
+﻿module CodeGenValidation_Types
+
+// convert OpenApi representation to something more useful for codegen
+
+type EnumTargets =
+    | IntEnum of int array
+    | LongEnum of int64 array
+    | FloatEnum of float array
+    | StringEnum of string array
+    with
+    member s.TypeEquals v =
+        match s,v with
+        | IntEnum _, IntEnum _
+        | LongEnum _, LongEnum _
+        | FloatEnum _, FloatEnum _
+        | StringEnum _, StringEnum _ -> true
+        | _ -> false
+
+type MultipleOfTargets =
+    | IntMultiple of int
+    | LongMultiple of int64
+    with
+    member s.TypeEquals v =
+        match s,v with
+        | IntMultiple _, IntMultiple _
+        | LongMultiple _, LongMultiple _ -> true
+        | _ -> false
+
+type RangeValues<'a> =
+    | Min of 'a
+    | Max of 'a
+    | Both of 'a*'a
+
+type BuiltInAttribute =
+    | IntRange of int RangeValues
+    | FloatRange of float RangeValues
+    | MinLength of int
+    | MaxLength of int
+    | Required
+    with
+    member s.TypeEquals v =
+        match s,v with
+        | IntRange _, IntRange _
+        | FloatRange _, FloatRange _
+        | MinLength _, MinLength _
+        | MaxLength _, MaxLength _
+        | Required, Required -> true
+        | _ -> false
+
+/// as we've got no way to define attribute which depends on the type to which it's applied
+/// without code-generating a reflection
+/// this attribute should be special-cased to be created with validity as parameter
+type SpecialCasedCustomValidationAttribute =
+    | UniqueItems
+    with
+    member s.TypeEquals v =
+        match s,v with
+        | UniqueItems, UniqueItems -> true
+
+type CustomBasicValidationAttribute =
+    | EnumAttribute of EnumTargets
+    | MultipleOf of MultipleOfTargets
+    | LongRange of int64 RangeValues
+    // built-in doesn't work for some reason
+    | RegexPattern of string
+    with
+    member s.TypeEquals v =
+        match s,v with
+        | EnumAttribute _, EnumAttribute _
+        | MultipleOf _, MultipleOf _
+        | RegexPattern _, RegexPattern _
+        | LongRange _, LongRange _
+        | _ -> false
+
+type ValidationAttribute =
+    | CustomAttribute of CustomBasicValidationAttribute
+    | BuiltInAttribute of BuiltInAttribute
+    | SpecialCasedCustomValidationAttribute of SpecialCasedCustomValidationAttribute
+    // no type recursion for arrays and options
+    // because they should be handled via
+    // recursive validator function
+    // instead of generating a stuff like
+    // ArrayItemOptionValueArrayItemMinLengthAttribute
+    with
+    member s.TypeEquals v =
+        match s,v with
+        | CustomAttribute a, CustomAttribute b -> a.TypeEquals b
+        | BuiltInAttribute a, BuiltInAttribute b -> a.TypeEquals b
+        | SpecialCasedCustomValidationAttribute a, SpecialCasedCustomValidationAttribute b -> a.TypeEquals b
+        | _ -> false

--- a/src/GiraffeGenerator.Core/Configuration.fs
+++ b/src/GiraffeGenerator.Core/Configuration.fs
@@ -10,11 +10,13 @@ type DateTimeGeneratedType =
 type Configuration =
     {
         UseNodaTime: bool
+        AllowUnqualifiedAccess: bool
         MapDateTimeInto: DateTimeGeneratedType
         ModuleName: string option
     }
 
 let mutable value =
     { UseNodaTime = false
+      AllowUnqualifiedAccess = false
       MapDateTimeInto = OffsetDateTime
       ModuleName = None }

--- a/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
+++ b/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="CodeGenErrorsDU.fs" />
     <Compile Include="CodeGenValidation_Types.fs" />
     <Compile Include="CodeGenValidation_TypeGeneration.fs" />
+    <Compile Include="CodeGenValidation.fs" />
     <Compile Include="CodeGen.fs" />
   </ItemGroup>
 

--- a/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
+++ b/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="OpenApi.fs" />
     <Compile Include="OpenApiToAstTypesMatchingAndConversion.fs" />
     <Compile Include="CodeGenErrorsDU.fs" />
+    <Compile Include="CodeGenValidation_Types.fs" />
     <Compile Include="CodeGen.fs" />
   </ItemGroup>
 

--- a/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
+++ b/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="OpenApiToAstTypesMatchingAndConversion.fs" />
     <Compile Include="CodeGenErrorsDU.fs" />
     <Compile Include="CodeGenValidation_Types.fs" />
+    <Compile Include="CodeGenValidation_TypeGeneration.fs" />
     <Compile Include="CodeGen.fs" />
   </ItemGroup>
 

--- a/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
+++ b/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="CodeGenErrorsDU.fs" />
     <Compile Include="CodeGenValidation_Types.fs" />
     <Compile Include="CodeGenValidation_TypeGeneration.fs" />
+    <Compile Include="CodeGenValidation_InstanceGeneration.fs" />
     <Compile Include="CodeGenValidation.fs" />
     <Compile Include="CodeGen.fs" />
   </ItemGroup>

--- a/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
+++ b/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="CodeGenValidation_Types.fs" />
     <Compile Include="CodeGenValidation_TypeGeneration.fs" />
     <Compile Include="CodeGenValidation_InstanceGeneration.fs" />
+    <Compile Include="CodeGenValidation_LogicGeneration.fs" />
     <Compile Include="CodeGenValidation.fs" />
     <Compile Include="CodeGen.fs" />
   </ItemGroup>

--- a/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
+++ b/src/GiraffeGenerator.Core/GiraffeGenerator.Core.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="Configuration.fs" />
     <Compile Include="AST.fs" />
     <Compile Include="ASTExt.fs" />
+    <Compile Include="OpenApiValidation.fs" />
     <Compile Include="OpenApi.fs" />
     <Compile Include="OpenApiToAstTypesMatchingAndConversion.fs" />
     <Compile Include="CodeGenErrorsDU.fs" />

--- a/src/GiraffeGenerator.Core/OpenApi.fs
+++ b/src/GiraffeGenerator.Core/OpenApi.fs
@@ -7,6 +7,7 @@ open Microsoft.OpenApi.Readers
 open System.IO
 open System.Text.RegularExpressions
 open NodaTime.Text
+open OpenApiValidation
 
 let inline trimLower (s: string) =
     if isNull s then None else
@@ -33,7 +34,7 @@ type Docs =
 /// URI is not standard, but included
 /// It could be anything
 type StringFormat =
-    | String
+    | String of StringValidation option
     | Byte
     | Binary
     | DateString
@@ -41,8 +42,8 @@ type StringFormat =
     | PasswordString
     | Custom of string
     
-    static member Parse (maybeFormat: string Option) =
-        if maybeFormat.IsNone then String else
+    static member Parse schema (maybeFormat: string Option) =
+        if maybeFormat.IsNone then String (StringValidation.TryParse schema) else
         match maybeFormat.Value with
         | "byte" -> Byte
         | "binary" -> Binary
@@ -61,22 +62,22 @@ let (|ArrayKind|ObjectKind|PrimKind|) (schema: OpenApiSchema) =
         
 /// All primitive type kinds for a fields in type definitions
 type PrimTypeKind =
-    | Int
-    | Long
-    | Double
+    | Int of IntValidation option
+    | Long of LongValidation option
+    | Double of FloatValidation option
     | Bool
     | Any
     | String of StringFormat
     
-    static member Parse (typeKind: string, format: string) =
+    static member Parse (typeKind: string, schema: OpenApiSchema) =
         
-        match trimLower typeKind, trimLower format with
-        | Some "integer", Some "int64" -> Long 
-        | Some "integer", _ -> Int
-        | Some "number", _ -> Double
+        match trimLower typeKind, trimLower schema.Format with
+        | Some "integer", Some "int64" -> Long (LongValidation.TryParse schema) 
+        | Some "integer", _ -> Int (IntValidation.TryParse schema)
+        | Some "number", _ -> Double (FloatValidation.TryParse schema)
         | Some "boolean", _ -> Bool
-        | Some "string", maybeStringFormat -> String(StringFormat.Parse maybeStringFormat)
-        | _ -> failwithf "Unexpected type: %s and format: %A" typeKind format
+        | Some "string", maybeStringFormat -> String(StringFormat.Parse schema maybeStringFormat)
+        | _ -> failwithf "Unexpected type: %s and format: %A" typeKind schema.Format
         
     member s.GetDefaultLiteral (value: IOpenApiPrimitive) =
         let fw t = failwithf "%s literal has been found for non-%s type" t t
@@ -128,19 +129,35 @@ type PrimTypeKind =
                 | _ -> None
             | _ -> None
         
+        let inline failIfInvalid validation = failIfInvalid "Default value" validation
+        
         let defaultMatch () =    
             match value with
             | :? OpenApiInteger as int ->
                 match s with
-                | Int -> DefaultableKind.Integer int.Value
-                | Long -> DefaultableKind.Long (int64 int.Value)
+                | Int validation ->
+                    do failIfInvalid validation int.Value
+                    DefaultableKind.Integer int.Value
+                | Long validation ->
+                    let value = int64 int.Value
+                    do failIfInvalid validation value
+                    DefaultableKind.Long value 
                 | _ -> fw "integer"
             | :? OpenApiLong as long ->
                 match s with
-                | Int ->  DefaultableKind.Long (int64 long.Value) 
-                | Long -> DefaultableKind.Long long.Value
+                | Int validation ->
+                    do failIfInvalid validation (int32 long.Value)
+                    DefaultableKind.Long long.Value
+                | Long validation ->
+                    do failIfInvalid validation long.Value
+                    DefaultableKind.Long long.Value
                 | _ -> fw "int64"
-            | :? OpenApiDouble as double -> oneWay Double double DefaultableKind.Double
+            | :? OpenApiDouble as double ->
+                match s with
+                | Double validation ->
+                    do failIfInvalid validation double.Value
+                    DefaultableKind.Double double.Value
+                | _ -> fw "double" 
             | :? OpenApiBoolean as bool -> oneWay Bool bool DefaultableKind.Boolean
             | :? OpenApiDateTime as dateTime -> oneWay (String DateTimeString) dateTime DefaultableKind.DateTime
             | :? OpenApiDate as date -> oneWay (String DateString) date DefaultableKind.Date
@@ -150,8 +167,10 @@ type PrimTypeKind =
                 | String s ->
                     let inline oneWay x = oneWay (String s) x
                     match s with
-                    | PasswordString
-                    | StringFormat.String -> oneWay str DefaultableKind.String
+                    | PasswordString -> oneWay str DefaultableKind.String
+                    | StringFormat.String validation ->
+                        do failIfInvalid validation str.Value
+                        oneWay str DefaultableKind.String
                     | Custom "uri"
                     | Custom "uriref" -> oneWay {| Value = System.Uri str.Value |} DefaultableKind.Uri
                     | Custom "uuid"
@@ -247,7 +266,7 @@ and DUKind =
 /// Array, Option and Object could recursively contains similar types
 and TypeKind =
     | Prim of PrimTypeKind
-    | Array of TypeKind * Option<DefaultableKind>
+    | Array of TypeKind * Option<DefaultableKind> * Option<ArrayValidation>
     | Option of TypeKind
     | Object of ObjectKind
     | DU of DUKind
@@ -263,14 +282,14 @@ and TypeKind =
                     let isObj = match arrItm with | TypeKind.Object _ -> true | _ -> false 
                     if def.IsSome && isObj then
                         failwith "Default values aren't supported for entire objects"
-                    Array (arrItm, def), None
+                    Array (arrItm, def, ArrayValidation.TryParse schema), None
                 | ObjectKind schema ->
                     if schema.Default <> null then
                         failwith "Default values aren't supported for entire objects"
                     else
                         ObjectKind.Create(schema) |> Object, None
                 | PrimKind primType ->
-                    let prim = PrimTypeKind.Parse(primType, schema.Format)
+                    let prim = PrimTypeKind.Parse(primType, schema)
                     let def = schema.Default |> Option.ofObj |> Option.map (fun x -> x:?>IOpenApiPrimitive) |> Option.map (prim.GetDefaultLiteral)
                     Prim prim, def
             if schema.Nullable && def.IsNone then

--- a/src/GiraffeGenerator.Core/OpenApiToAstTypesMatchingAndConversion.fs
+++ b/src/GiraffeGenerator.Core/OpenApiToAstTypesMatchingAndConversion.fs
@@ -109,7 +109,18 @@ let rec extractResponseSynType externalName =
         if fields.IsEmpty then objType else anonRecord fields
     | DU du -> synType du.Name
     | NoType -> unitType
-
+    
+let rec extractBodyBindingSynType defaultTypeName nameFromSchema kind =
+    match defaultTypeName with
+    | None -> extractResponseSynType (Some nameFromSchema) kind
+    | Some generatedName ->
+        let rec extract kind =
+            match kind with
+            | Array (kind, _, _) -> extract kind |> arrayOf
+            | Option kind -> extract kind |> optionOf
+            | Object _ -> synType generatedName
+            | _ -> failwith "no generated name can exist for non-object type"
+        extract kind
 /// Creating AST XML docs from API representation
 let xml: Docs option -> PreXmlDoc =
     function

--- a/src/GiraffeGenerator.Core/OpenApiToAstTypesMatchingAndConversion.fs
+++ b/src/GiraffeGenerator.Core/OpenApiToAstTypesMatchingAndConversion.fs
@@ -451,7 +451,7 @@ module rec DefaultsGeneration =
     let private generateDefaultMappingFunFromKind defaultsMap kind sourceDef nameFromSchema =
         let param = "src"
         let hasDefaults, recordExpr = generateDefaultMapping defaultsMap kind sourceDef nameFromSchema param
-        hasDefaults, lambda (simplePats [SynSimplePat.Typed(simplePat param, extractResponseSynType (Some nameFromSchema) kind, r)]) recordExpr
+        hasDefaults, lambda (singleTypedPat param <| extractResponseSynType (Some nameFromSchema) kind) recordExpr
 
     let private generateDefaultMappingFunFromMapping defaultsMap sourceDef (mapping: GeneratedOptionalTypeMapping) =
         let param = "src"
@@ -459,7 +459,7 @@ module rec DefaultsGeneration =
         let bindWithTypeAndReturn =
             letExprComplex (SynPat.Typed(SynPat.Named(SynPat.Wild r, ident "v", false, None, r), synType mapping.OriginalName, r))
                 recordExpr (identExpr "v")
-        hasDefaults, lambda (simplePats [SynSimplePat.Typed(simplePat param, synType mapping.GeneratedName, r)]) bindWithTypeAndReturn
+        hasDefaults, lambda (singleTypedPat param <| synType mapping.GeneratedName) bindWithTypeAndReturn
         
     let generateDefaultMappingFunFromSchema defaultsMap mapping (schema: TypeSchema) =
         let hasDefault, fn = generateDefaultMappingFunFromMapping defaultsMap schema.DefaultValue mapping

--- a/src/GiraffeGenerator.Core/OpenApiValidation.fs
+++ b/src/GiraffeGenerator.Core/OpenApiValidation.fs
@@ -18,8 +18,8 @@
         else
             let subMessage = sprintf "%s %A" (if not boundary.Exclusive then "or equal to" else "") boundary.Value
             message subMessage |> Some
-    let inline private checkMinBoundary value = checkBoundary (>) (sprintf "should be greater than %s") value
-    let inline private checkMaxBoundary value = checkBoundary (<) (sprintf "should be lesser than %s") value
+    let inline private checkMinBoundary value = checkBoundary (<) (sprintf "should be greater than %s") value
+    let inline private checkMaxBoundary value = checkBoundary (>) (sprintf "should be lesser than %s") value
     
     let inline private checkMultipleOf value divisor =
         if value % divisor = LanguagePrimitives.GenericZero then None

--- a/src/GiraffeGenerator.Core/OpenApiValidation.fs
+++ b/src/GiraffeGenerator.Core/OpenApiValidation.fs
@@ -1,0 +1,247 @@
+﻿module OpenApiValidation
+    open System.Text.RegularExpressions
+    open AST
+    open Microsoft.OpenApi.Any
+    open Microsoft.OpenApi.Models
+
+    type NumberBoundary<'n> =
+        {
+            Value: 'n
+            Exclusive: bool
+        }
+    // the following block contains functions used for design-time values (e.g. defaults) validation
+    
+    // numerics validation
+    let private checkBoundary op message value boundary =
+        let isValid = not boundary.Exclusive && boundary.Value = value || op boundary.Value value
+        if isValid then None
+        else
+            let subMessage = sprintf "%s %A" (if not boundary.Exclusive then "or equal to" else "") boundary.Value
+            message subMessage |> Some
+    let inline private checkMinBoundary value = checkBoundary (>) (sprintf "should be greater than %s") value
+    let inline private checkMaxBoundary value = checkBoundary (<) (sprintf "should be lesser than %s") value
+    
+    let inline private checkMultiplyOf value divisor =
+        if value % divisor = LanguagePrimitives.GenericZero then None
+        else sprintf "should be a multiply of %d" divisor |> Some
+    
+    // numerics or string validation
+    
+    let inline private checkEnum value enum =
+        if enum |> Array.contains value then None
+        else
+            enum
+            |> Array.map string
+            |> String.concat "; "
+            |> sprintf "should be one of [%s]"
+            |> Some
+    
+    // array or string length validation
+    let inline private getLength value = (^v: (member Length: int) value)
+    let inline private checkLength boundaryChecker value measure length =
+        {
+            Value = length
+            Exclusive = false
+        }
+        |> boundaryChecker (getLength value)
+        |> Option.map ^ sprintf "%s count %s" measure
+    let inline private checkMinLength value = checkLength checkMinBoundary value
+    let inline private checkMaxLength value = checkLength checkMaxBoundary value
+
+    let inline private failIfInvalidImpl name value errs =
+        let errs =
+            errs
+            |> List.choose id
+            |> String.concat "; "
+        if errs.Length > 0 then
+            failwithf "%s %A is invalid: %s" name value errs       
+        
+    
+    // and here come the validation rule models themselves
+    
+    type IntValidation =
+        {
+            MultipleOf: int option
+            Minimum: NumberBoundary<int> option
+            Maximum: NumberBoundary<int> option
+            EnumValues: int array option
+        }
+        with
+        member s.FailIfInvalid (name, value) =
+            failIfInvalidImpl name value
+                [
+                    s.MultipleOf |> Option.bind (checkMultiplyOf value)
+                    s.Minimum |> Option.bind (checkMinBoundary value)
+                    s.Maximum |> Option.bind (checkMaxBoundary value)
+                    s.EnumValues |> Option.bind (checkEnum value)
+                ]         
+        static member TryParse (schema: OpenApiSchema): IntValidation option =
+            {
+                MultipleOf =
+                    schema.MultipleOf
+                    |> Option.ofNullable
+                    |> Option.map int
+                Minimum =
+                    schema.Minimum
+                    |> Option.ofNullable
+                    |> Option.map int
+                    |> Option.map ^ fun v ->
+                        { Value = v; Exclusive = schema.ExclusiveMinimum |> Option.ofNullable |> Option.defaultValue false }
+                Maximum =
+                    schema.Maximum
+                    |> Option.ofNullable
+                    |> Option.map int
+                    |> Option.map ^ fun v ->
+                        { Value = v; Exclusive = schema.ExclusiveMaximum |> Option.ofNullable |> Option.defaultValue false }
+                EnumValues =
+                    schema.Enum
+                    |> Option.ofObj
+                    |> Option.map (Seq.map (fun x -> (x :?> OpenApiInteger).Value) >> Seq.toArray)
+                    |> Option.filter (Array.length >> (<>) 0)
+            }
+            |> Some
+            |> Option.filter ^ fun x -> x.MultipleOf.IsSome || x.Minimum.IsSome || x.Maximum.IsSome || x.EnumValues.IsSome
+                
+    type LongValidation =
+        {
+            MultipleOf: int64 option
+            Minimum: NumberBoundary<int64> option
+            Maximum: NumberBoundary<int64> option
+            EnumValues: int64 array option
+        }
+        with
+        member s.FailIfInvalid (name, value) =
+            failIfInvalidImpl name value
+                [
+                    s.MultipleOf |> Option.bind (checkMultiplyOf value)
+                    s.Minimum |> Option.bind (checkMinBoundary value)
+                    s.Maximum |> Option.bind (checkMaxBoundary value)
+                    s.EnumValues |> Option.bind (checkEnum value)
+                ]
+        static member TryParse (schema: OpenApiSchema): LongValidation option =
+            {
+                MultipleOf =
+                    schema.MultipleOf
+                    |> Option.ofNullable
+                    |> Option.map int64
+                Minimum =
+                    schema.Minimum
+                    |> Option.ofNullable
+                    |> Option.map int64
+                    |> Option.map ^ fun v ->
+                        { Value = v; Exclusive = schema.ExclusiveMinimum |> Option.ofNullable |> Option.defaultValue false }
+                Maximum =
+                    schema.Maximum
+                    |> Option.ofNullable
+                    |> Option.map int64
+                    |> Option.map ^ fun v ->
+                        { Value = v; Exclusive = schema.ExclusiveMaximum |> Option.ofNullable |> Option.defaultValue false }
+                EnumValues =
+                    schema.Enum
+                    |> Option.ofObj
+                    |> Option.map (Seq.map (fun x -> (x :?> OpenApiLong).Value) >> Seq.toArray)
+                    |> Option.filter (Array.length >> (<>) 0)
+            }
+            |> Some
+            |> Option.filter ^ fun x -> x.MultipleOf.IsSome || x.Minimum.IsSome || x.Maximum.IsSome || x.EnumValues.IsSome
+
+    type FloatValidation =
+        {
+            Minimum: NumberBoundary<float> option
+            Maximum: NumberBoundary<float> option
+            EnumValues: float array option
+        }
+        with
+        member s.FailIfInvalid (name, value) =
+            failIfInvalidImpl name value
+                [
+                    s.Minimum |> Option.bind (checkMinBoundary value)
+                    s.Maximum |> Option.bind (checkMaxBoundary value)
+                    s.EnumValues |> Option.bind (checkEnum value)
+                ]
+        static member TryParse (schema: OpenApiSchema): FloatValidation option =
+            {
+                Minimum =
+                    schema.Minimum
+                    |> Option.ofNullable
+                    |> Option.map float
+                    |> Option.map ^ fun v ->
+                        { Value = v; Exclusive = schema.ExclusiveMinimum |> Option.ofNullable |> Option.defaultValue false }
+                Maximum =
+                    schema.Maximum
+                    |> Option.ofNullable
+                    |> Option.map float
+                    |> Option.map ^ fun v ->
+                        { Value = v; Exclusive = schema.ExclusiveMaximum |> Option.ofNullable |> Option.defaultValue false }
+                EnumValues =
+                    schema.Enum
+                    |> Option.ofObj
+                    |> Option.map (Seq.map (fun x -> (x :?> OpenApiDouble).Value) >> Seq.toArray)
+                    |> Option.filter (Array.length >> (<>) 0)
+            }
+            |> Some
+            |> Option.filter ^ fun x -> x.Minimum.IsSome || x.Maximum.IsSome || x.EnumValues.IsSome
+                
+    type StringValidation =
+        {
+            /// inclusive: https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.7
+            MinLength: int option
+            /// inclusive: https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.6
+            MaxLength: int option
+            Pattern: string option
+            EnumValues: string array option
+        }
+        with
+        member s.FailIfInvalid (name, value) =
+            failIfInvalidImpl name value
+                [
+                    s.MinLength |> Option.bind (checkMinLength value "characters")
+                    s.MaxLength |> Option.bind (checkMaxLength value "characters")
+                    s.EnumValues |> Option.bind (checkEnum value)
+                    s.Pattern
+                    |> Option.filter (fun pattern -> Regex(pattern, RegexOptions.ECMAScript).IsMatch value)
+                    |> Option.map ^ sprintf "should match pattern /%s/"
+                ]
+        static member TryParse (schema: OpenApiSchema): StringValidation option =
+            {
+                MinLength = schema.MinLength |> Option.ofNullable
+                MaxLength = schema.MaxLength |> Option.ofNullable
+                Pattern = schema.Pattern |> Option.ofObj
+                EnumValues =
+                    schema.Enum
+                    |> Option.ofObj
+                    |> Option.map (Seq.map (fun x -> (x :?> OpenApiString).Value) >> Seq.toArray)
+                    |> Option.filter (Array.length >> (<>) 0)
+            }
+            |> Some
+            |> Option.filter ^ fun x -> x.MinLength.IsSome || x.MaxLength.IsSome || x.Pattern.IsSome || x.EnumValues.IsSome
+                
+    type ArrayValidation =
+        {
+            MinItems: int option
+            MaxItems: int option
+            UniqueItems: bool
+        }
+        with
+        member s.FailIfInvalid (name, value) =
+            failIfInvalidImpl name value
+                [
+                    s.MinItems |> Option.bind (checkMinLength value "items")
+                    s.MaxItems |> Option.bind (checkMaxLength value "items")
+                    if s.UniqueItems && Array.length value <> (Set value).Count then
+                        Some "should contain only unique values"
+                ]
+        static member TryParse (schema: OpenApiSchema): ArrayValidation option =
+            {
+                MinItems = schema.MinItems |> Option.ofNullable
+                MaxItems = schema.MaxItems |> Option.ofNullable
+                UniqueItems = schema.UniqueItems |> Option.ofNullable |> Option.defaultValue false
+            }
+            |> Some
+            |> Option.filter ^ fun x -> x.MinItems.IsSome || x.MaxItems.IsSome || x.UniqueItems
+    
+    let inline failIfInvalid name validation value =
+        validation
+        |> Option.map(fun validation ->
+            (^validation:(member FailIfInvalid: string -> ^a -> unit) validation, name, value))
+        |> Option.defaultValue ()

--- a/src/GiraffeGenerator.Core/OpenApiValidation.fs
+++ b/src/GiraffeGenerator.Core/OpenApiValidation.fs
@@ -239,8 +239,8 @@
                 |> Option.filter (fun pattern ->
                     try
                         do Regex(pattern, RegexOptions.ECMAScript) |> ignore
-                        true
-                    with | _ -> false)
+                        false
+                    with | _ -> true)
                 |> Option.map (failwithf "pattern /%s/ should be a valid ECMA regexp")
                 |> Option.defaultValue ()
             {

--- a/src/GiraffeGenerator.Sdk/build/GiraffeGenerator.Sdk.targets
+++ b/src/GiraffeGenerator.Sdk/build/GiraffeGenerator.Sdk.targets
@@ -5,6 +5,7 @@
         <ItemGroup>
             <GiraffeGeneratorSource Include="%(Compile.OpenApiSpecFile)" Condition=" '%(Compile.OpenApiSpecFile)' != '' ">
                 <OutputPath>$([System.IO.Path]::GetFullPath('%(Compile.FullPath)'))</OutputPath>
+                <AllowUnqualifiedAccess Condition=" '%(Compile.OpenApiAllowUnqualifiedAccess)' == 'true' ">true</AllowUnqualifiedAccess>
                 <UseNodaTime Condition=" '%(Compile.OpenApiUseNodaTime)' == 'true' ">true</UseNodaTime>
                 <ModuleName>%(Compile.OpenApiModuleName)</ModuleName>
                 <MapDateTimeInto>%(Compile.OpenApiMapDateTimeInto)</MapDateTimeInto>
@@ -16,6 +17,7 @@
                 <OutputPath Condition=" '%(GiraffeGeneratorSource.OutputPath)' != '' ">$([System.IO.Path]::GetFullPath('%(GiraffeGeneratorSource.OutputPath)'))</OutputPath>
                 <OutputPath Condition=" '%(GiraffeGeneratorSource.OutputPath)' == '' ">%(GiraffeGeneratorSource.FullPath).fs</OutputPath>
                 <ModuleName>%(GiraffeGeneratorSource.ModuleName)</ModuleName>
+                <AllowUnqualifiedAccess Condition=" '%(GiraffeGeneratorSource.AllowUnqualifiedAccess)' == 'true' ">true</AllowUnqualifiedAccess>
                 <UseNodaTime Condition=" '%(GiraffeGeneratorSource.UseNodaTime)' == 'true' ">true</UseNodaTime>
                 <MapDateTimeInto>%(GiraffeGeneratorSource.MapDateTimeInto)</MapDateTimeInto>
             </GiraffeGeneratorCodegen>
@@ -58,6 +60,7 @@
             <_GiraffeGeneratorSdk_InputFileName>%(GiraffeGeneratorCodegen.Identity)</_GiraffeGeneratorSdk_InputFileName>
             <_GiraffeGeneratorSdk_OutputFileName>%(GiraffeGeneratorCodegen.OutputPath)</_GiraffeGeneratorSdk_OutputFileName>
             <_GiraffeGeneratorSdk_ModuleName>%(GiraffeGeneratorCodegen.ModuleName)</_GiraffeGeneratorSdk_ModuleName>
+            <_GiraffeGeneratorSdk_AllowUnqualifiedAccess Condition=" '%(GiraffeGeneratorCodegen.AllowUnqualifiedAccess)' == 'true' ">true</_GiraffeGeneratorSdk_AllowUnqualifiedAccess>
             <_GiraffeGeneratorSdk_UseNodaTime Condition=" '%(GiraffeGeneratorCodegen.UseNodaTime)' == 'true' ">true</_GiraffeGeneratorSdk_UseNodaTime>
             <_GiraffeGeneratorSdk_MapDateTimeInto>%(GiraffeGeneratorCodegen.MapDateTimeInto)</_GiraffeGeneratorSdk_MapDateTimeInto>
         </PropertyGroup>
@@ -67,6 +70,7 @@
             <GiraffeGeneratorSdk_Args Include='--outputfile "$(_GiraffeGeneratorSdk_OutputFileName)"' />
             <GiraffeGeneratorSdk_Args Condition=" '$(_GiraffeGeneratorSdk_ModuleName)' != '' " Include='--module-name "$(_GiraffeGeneratorSdk_ModuleName)"' />
             <GiraffeGeneratorSdk_Args Condition=" '$(_GiraffeGeneratorSdk_UseNodaTime)' == 'true' " Include='--use-noda-time' />
+            <GiraffeGeneratorSdk_Args Condition=" '$(_GiraffeGeneratorSdk_AllowUnqualifiedAccess)' == 'true' " Include='--allow-unqualified-access' />
             <GiraffeGeneratorSdk_Args Condition=" '$(_GiraffeGeneratorSdk_MapDateTimeInto)' != '' " Include='--map-date-time-into "$(_GiraffeGeneratorSdk_MapDateTimeInto)"' />
         </ItemGroup>
 

--- a/src/GiraffeGenerator/Program.fs
+++ b/src/GiraffeGenerator/Program.fs
@@ -21,6 +21,7 @@ type Config =
     | [<Mandatory>]Inputfile of string
     | [<Mandatory>]Outputfile of string
     | Module_Name of string
+    | Allow_Unqualified_Access
     | Use_Noda_Time
     | Map_Date_Time_Into of DateTimeGeneratedType
     
@@ -30,6 +31,7 @@ type Config =
             | Inputfile _ -> "Path to OpenAPI spec file to generate server implementation by"
             | Outputfile _ -> "Path to .fs file to write the source code generated"
             | Module_Name _ -> "Override module name for the server generated. Default is taken from the spec description"
+            | Allow_Unqualified_Access -> "Opts-out [<RequireQualifiedAccess>] generation for the module being generated"
             | Use_Noda_Time -> "Opts-in usage of NodaTime types"
             | Map_Date_Time_Into _ -> "Specifies NodaTime type used for date-time OpenAPI format"
 
@@ -47,6 +49,7 @@ let main argv =
         | Inputfile file -> inputFile <- file
         | Outputfile file -> outputFile <- file
         | Module_Name name -> Configuration.value <- { Configuration.value with ModuleName = Some name }
+        | Allow_Unqualified_Access -> Configuration.value <- { Configuration.value with AllowUnqualifiedAccess = true }
         | Use_Noda_Time -> Configuration.value <- { Configuration.value with UseNodaTime = true }
         | Map_Date_Time_Into kind -> Configuration.value <- { Configuration.value with MapDateTimeInto = kind.ToConfigType() }
     

--- a/tests/GiraffeGenerator.IntegrationTests/GiraffeGenerator.IntegrationTests.fsproj
+++ b/tests/GiraffeGenerator.IntegrationTests/GiraffeGenerator.IntegrationTests.fsproj
@@ -59,6 +59,7 @@
     <Compile Include="SpecWithValidationExtensibility.fs">
       <OpenApiModuleName>SpecWithValidationExtensibility</OpenApiModuleName>
       <OpenApiSpecFile>specs/specWithValidationExtensibility.yaml</OpenApiSpecFile>
+      <OpenApiAllowUnqualifiedAccess>true</OpenApiAllowUnqualifiedAccess>
     </Compile>
     <None Include="NuGet.Config" />
     <Compile Include="SpecSimpleTests.fs" />

--- a/tests/GiraffeGenerator.IntegrationTests/GiraffeGenerator.IntegrationTests.fsproj
+++ b/tests/GiraffeGenerator.IntegrationTests/GiraffeGenerator.IntegrationTests.fsproj
@@ -56,6 +56,10 @@
       <OpenApiModuleName>SpecWithValidation</OpenApiModuleName>
       <OpenApiSpecFile>specs/specWithValidation.yaml</OpenApiSpecFile>
     </Compile>
+    <Compile Include="SpecWithValidationExtensibility.fs">
+      <OpenApiModuleName>SpecWithValidationExtensibility</OpenApiModuleName>
+      <OpenApiSpecFile>specs/specWithValidationExtensibility.yaml</OpenApiSpecFile>
+    </Compile>
     <None Include="NuGet.Config" />
     <Compile Include="SpecSimpleTests.fs" />
     <Compile Include="SpecWithSchemasTests.fs" />
@@ -64,6 +68,7 @@
     <Compile Include="SpecGeneralForNodaTimeTests.fs" />
     <Compile Include="SpecForNodaTimeDateTimeInstantFormatHandlingTests.fs" />
     <Compile Include="SpecWithValidationTests.fs" />
+    <Compile Include="SpecWithValidationExtensibilityTests.fs" />
     <Content Include="RemoveGenerated.ps1" />
     <Content Include="specs\specWithSchemas.yaml" />
     <Content Include="specs\specWithParametersAndRequestBodySchemas.yaml" />
@@ -71,6 +76,7 @@
     <Content Include="specs\specForNodaTimeDateTimeFormatHandling.yaml" />
     <Content Include="specs\specWithArguments.yaml" />
     <Content Include="specs\specWithValidation.yaml" />
+    <Content Include="specs\specWithValidationExtensibility.yaml" />
     <Content Include="specs\specSimple.yaml" />
   </ItemGroup>
 

--- a/tests/GiraffeGenerator.IntegrationTests/GiraffeGenerator.IntegrationTests.fsproj
+++ b/tests/GiraffeGenerator.IntegrationTests/GiraffeGenerator.IntegrationTests.fsproj
@@ -52,6 +52,10 @@
       <OpenApiUseNodaTime>true</OpenApiUseNodaTime>
       <OpenApiSpecFile>specs/specForNodaTimeDateTimeFormatHandling.yaml</OpenApiSpecFile>
     </Compile>
+    <Compile Include="SpecWithValidation.fs">
+      <OpenApiModuleName>SpecWithValidation</OpenApiModuleName>
+      <OpenApiSpecFile>specs/specWithValidation.yaml</OpenApiSpecFile>
+    </Compile>
     <None Include="NuGet.Config" />
     <Compile Include="SpecSimpleTests.fs" />
     <Compile Include="SpecWithSchemasTests.fs" />
@@ -65,6 +69,7 @@
     <Content Include="specs\specGeneralForNodaTime.yaml" />
     <Content Include="specs\specForNodaTimeDateTimeFormatHandling.yaml" />
     <Content Include="specs\specWithArguments.yaml" />
+    <Content Include="specs\specWithValidation.yaml" />
     <Content Include="specs\specSimple.yaml" />
   </ItemGroup>
 

--- a/tests/GiraffeGenerator.IntegrationTests/GiraffeGenerator.IntegrationTests.fsproj
+++ b/tests/GiraffeGenerator.IntegrationTests/GiraffeGenerator.IntegrationTests.fsproj
@@ -63,6 +63,7 @@
     <Compile Include="SpecWithParametersAndRequestBodyTests.fs" />
     <Compile Include="SpecGeneralForNodaTimeTests.fs" />
     <Compile Include="SpecForNodaTimeDateTimeInstantFormatHandlingTests.fs" />
+    <Compile Include="SpecWithValidationTests.fs" />
     <Content Include="RemoveGenerated.ps1" />
     <Content Include="specs\specWithSchemas.yaml" />
     <Content Include="specs\specWithParametersAndRequestBodySchemas.yaml" />

--- a/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationExtensibilityTests.fs
+++ b/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationExtensibilityTests.fs
@@ -15,45 +15,46 @@ open Microsoft.AspNetCore.TestHost
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Logging
 open Newtonsoft.Json
+open SpecWithValidationExtensibility
 open Xunit
 
 type AlwaysFailValidationReplacer() =
-    interface SpecWithValidationExtensibility.IGiraffeValidator<SpecWithValidationExtensibility.GetTestValidationQuery> with
+    interface IGiraffeValidator<GetTestValidationQuery> with
         member _.Validate((_,_)) = [|
             ValidationResult("Never valid")
         |]
 
 type AlwaysFailValidationAugmenter() =
-    interface SpecWithValidationExtensibility.IGiraffeAdditionalValidator<SpecWithValidationExtensibility.GetTestValidationQuery> with
+    interface IGiraffeAdditionalValidator<GetTestValidationQuery> with
         member _.Validate((_,_)) = [|
             ValidationResult("Never valid")
         |]
 
 type NeverFailValidationReplacer() =
-    interface SpecWithValidationExtensibility.IGiraffeValidator<SpecWithValidationExtensibility.GetTestValidationQuery> with
+    interface IGiraffeValidator<GetTestValidationQuery> with
         member _.Validate((_,_)) = [||]
 
 type NeverFailValidationAugmenter() =
-    interface SpecWithValidationExtensibility.IGiraffeAdditionalValidator<SpecWithValidationExtensibility.GetTestValidationQuery> with
+    interface IGiraffeAdditionalValidator<GetTestValidationQuery> with
         member _.Validate((_,_)) = [||]
 
 type SpecWithValidationExtensibilityTests() =
     let specWithValidationService=
         {
-            new SpecWithValidationExtensibility.Service() with
+            new Service() with
                 member _.TestValidationInput ((_, _)) =
                     task {
                         return Choice1Of2 "ok"
                     }
                 member _.TestValidationInputError ((err, _)) =
                     task {
-                        return Choice2Of2 (SpecWithValidationExtensibility.argLocationErrorToString 0 err)
+                        return Choice2Of2 (argLocationErrorToString 0 err)
                     }
                 
         }
         
     let configureApp (app : IApplicationBuilder) =
-        app.UseGiraffe SpecWithValidationExtensibility.webApp
+        app.UseGiraffe webApp
         
     let jsonSettings =
         JsonSerializerSettings(Converters=[|optionConverter|])
@@ -99,7 +100,7 @@ type SpecWithValidationExtensibilityTests() =
     
     [<Fact>]
     let ``[replace validation: always fail] /test-validation?maxLengthRestrictedTo8String=12345678 -> 400 "Never valid"`` ()  = task {
-        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeValidator<_>, AlwaysFailValidationReplacer>())
+        let client = client (fun s -> s.AddSingleton<IGiraffeValidator<_>, AlwaysFailValidationReplacer>())
         let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=12345678")
         let! responseText = response.Content.ReadAsStringAsync()
         do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
@@ -108,7 +109,7 @@ type SpecWithValidationExtensibilityTests() =
     
     [<Fact>]
     let ``[replace validation: always fail] /test-validation?maxLengthRestrictedTo8String=123456789 -> 400 "Never valid"`` () = task {
-        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeValidator<_>, AlwaysFailValidationReplacer>())
+        let client = client (fun s -> s.AddSingleton<IGiraffeValidator<_>, AlwaysFailValidationReplacer>())
         let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=123456789")
         let! responseText = response.Content.ReadAsStringAsync()
         do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
@@ -117,7 +118,7 @@ type SpecWithValidationExtensibilityTests() =
     
     [<Fact>]
     let ``[augment validation: always fail] /test-validation?maxLengthRestrictedTo8String=12345678 -> 400 "Never valid"`` ()  = task {
-        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
+        let client = client (fun s -> s.AddSingleton<IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
         let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=12345678")
         let! responseText = response.Content.ReadAsStringAsync()
         do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
@@ -126,7 +127,7 @@ type SpecWithValidationExtensibilityTests() =
     
     [<Fact>]
     let ``[augment validation: always fail] /test-validation?maxLengthRestrictedTo8String=123456789 -> 400 "Never valid, must be a string or array type with a maximum length of '8'"`` () = task {
-        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
+        let client = client (fun s -> s.AddSingleton<IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
         let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=123456789")
         let! responseText = response.Content.ReadAsStringAsync()
         do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
@@ -137,8 +138,8 @@ type SpecWithValidationExtensibilityTests() =
     [<Fact>]
     let ``[replace&augment validation: always fail] /test-validation?maxLengthRestrictedTo8String=12345678 -> 400 "Never valid, Never valid"`` ()  = task {
         let client = client (fun s ->
-            s.AddSingleton<SpecWithValidationExtensibility.IGiraffeValidator<_>, AlwaysFailValidationReplacer>()
-             .AddSingleton<SpecWithValidationExtensibility.IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
+            s.AddSingleton<IGiraffeValidator<_>, AlwaysFailValidationReplacer>()
+             .AddSingleton<IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
         let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=12345678")
         let! responseText = response.Content.ReadAsStringAsync()
         do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
@@ -151,8 +152,8 @@ type SpecWithValidationExtensibilityTests() =
     [<Fact>]
     let ``[replace&augment validation: always fail] /test-validation?maxLengthRestrictedTo8String=123456789 -> 400 "Never valid, Never valid'"`` () = task {
         let client = client (fun s ->
-            s.AddSingleton<SpecWithValidationExtensibility.IGiraffeValidator<_>, AlwaysFailValidationReplacer>()
-             .AddSingleton<SpecWithValidationExtensibility.IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
+            s.AddSingleton<IGiraffeValidator<_>, AlwaysFailValidationReplacer>()
+             .AddSingleton<IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
         let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=123456789")
         let! responseText = response.Content.ReadAsStringAsync()
         do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
@@ -164,7 +165,7 @@ type SpecWithValidationExtensibilityTests() =
     
     [<Fact>]
     let ``[replace validation: never fail] /test-validation?maxLengthRestrictedTo8String=12345678 -> 200 "ok"`` ()  = task {
-        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeValidator<_>, NeverFailValidationReplacer>())
+        let client = client (fun s -> s.AddSingleton<IGiraffeValidator<_>, NeverFailValidationReplacer>())
         let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=12345678")
         let! responseText = response.Content.ReadAsStringAsync()
         do Assert.Equal("\"ok\"", responseText)

--- a/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationExtensibilityTests.fs
+++ b/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationExtensibilityTests.fs
@@ -1,0 +1,199 @@
+﻿namespace GiraffeGenerator.IntegrationTests
+
+open System.ComponentModel.DataAnnotations
+open System.Net
+open System.Net.Http
+open System.Text
+open FSharp.Control.Tasks.V2.ContextInsensitive
+open System
+open Giraffe
+open Giraffe.Serialization.Json
+open Microsoft.AspNetCore
+open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Hosting
+open Microsoft.AspNetCore.TestHost
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Logging
+open Newtonsoft.Json
+open Xunit
+
+type AlwaysFailValidationReplacer() =
+    interface SpecWithValidationExtensibility.IGiraffeValidator<SpecWithValidationExtensibility.GetTestValidationQuery> with
+        member _.Validate((_,_)) = [|
+            ValidationResult("Never valid")
+        |]
+
+type AlwaysFailValidationAugmenter() =
+    interface SpecWithValidationExtensibility.IGiraffeAdditionalValidator<SpecWithValidationExtensibility.GetTestValidationQuery> with
+        member _.Validate((_,_)) = [|
+            ValidationResult("Never valid")
+        |]
+
+type NeverFailValidationReplacer() =
+    interface SpecWithValidationExtensibility.IGiraffeValidator<SpecWithValidationExtensibility.GetTestValidationQuery> with
+        member _.Validate((_,_)) = [||]
+
+type NeverFailValidationAugmenter() =
+    interface SpecWithValidationExtensibility.IGiraffeAdditionalValidator<SpecWithValidationExtensibility.GetTestValidationQuery> with
+        member _.Validate((_,_)) = [||]
+
+type SpecWithValidationExtensibilityTests() =
+    let specWithValidationService=
+        {
+            new SpecWithValidationExtensibility.Service() with
+                member _.TestValidationInput ((_, _)) =
+                    task {
+                        return Choice1Of2 "ok"
+                    }
+                member _.TestValidationInputError ((err, _)) =
+                    task {
+                        return Choice2Of2 (SpecWithValidationExtensibility.argLocationErrorToString 0 err)
+                    }
+                
+        }
+        
+    let configureApp (app : IApplicationBuilder) =
+        app.UseGiraffe SpecWithValidationExtensibility.webApp
+        
+    let jsonSettings =
+        JsonSerializerSettings(Converters=[|optionConverter|])
+
+    let configureServices (services : IServiceCollection) =
+        services
+            .AddGiraffe()
+            .AddSingleton<IJsonSerializer>(NewtonsoftJsonSerializer(jsonSettings))
+            .AddSingleton(specWithValidationService)
+        |> ignore
+
+    let configureLogging (loggerBuilder : ILoggingBuilder) =
+        loggerBuilder.AddFilter(fun lvl -> lvl.Equals LogLevel.Error)
+                     .AddConsole()
+                     .AddDebug() |> ignore
+
+    let webHostBuilder addServices =
+        WebHost.CreateDefaultBuilder()
+            .Configure(Action<IApplicationBuilder> configureApp)
+            .ConfigureServices(addServices >> configureServices)
+            .ConfigureLogging(configureLogging)
+            
+    let server addServices = new TestServer(webHostBuilder addServices)
+    let client addServices = (server addServices).CreateClient()
+    
+    [<Fact>]
+    let ``[no extensions (baseline)] /test-validation?maxLengthRestrictedTo8String=12345678 -> 200 "ok"`` ()  = task {
+        let client = client id
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=12345678")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal("\"ok\"", responseText)
+        do Assert.Equal(HttpStatusCode.OK, response.StatusCode)
+    }
+    
+    [<Fact>]
+    let ``[no extensions (baseline)] /test-validation?maxLengthRestrictedTo8String=123456789 -> 400 "must be a string or array type with a maximum length of '8'"`` () = task {
+        let client = client id
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=123456789")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
+        do Assert.Contains("must be a string or array type with a maximum length of '8'", responseText)
+    }
+    
+    [<Fact>]
+    let ``[replace validation: always fail] /test-validation?maxLengthRestrictedTo8String=12345678 -> 400 "Never valid"`` ()  = task {
+        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeValidator<_>, AlwaysFailValidationReplacer>())
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=12345678")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
+        do Assert.Contains("Never valid", responseText)
+    }
+    
+    [<Fact>]
+    let ``[replace validation: always fail] /test-validation?maxLengthRestrictedTo8String=123456789 -> 400 "Never valid"`` () = task {
+        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeValidator<_>, AlwaysFailValidationReplacer>())
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=123456789")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
+        do Assert.Contains("Never valid", responseText)
+    }
+    
+    [<Fact>]
+    let ``[augment validation: always fail] /test-validation?maxLengthRestrictedTo8String=12345678 -> 400 "Never valid"`` ()  = task {
+        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=12345678")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
+        do Assert.Contains("Never valid", responseText)
+    }
+    
+    [<Fact>]
+    let ``[augment validation: always fail] /test-validation?maxLengthRestrictedTo8String=123456789 -> 400 "Never valid, must be a string or array type with a maximum length of '8'"`` () = task {
+        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=123456789")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
+        do Assert.Contains("Never valid", responseText)
+        do Assert.Contains("must be a string or array type with a maximum length of '8'", responseText)
+    }
+    
+    [<Fact>]
+    let ``[replace&augment validation: always fail] /test-validation?maxLengthRestrictedTo8String=12345678 -> 400 "Never valid, Never valid"`` ()  = task {
+        let client = client (fun s ->
+            s.AddSingleton<SpecWithValidationExtensibility.IGiraffeValidator<_>, AlwaysFailValidationReplacer>()
+             .AddSingleton<SpecWithValidationExtensibility.IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=12345678")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
+        do Assert.Contains("Never valid", responseText)
+        let idx1 = responseText.IndexOf "Never valid"
+        let idx2 = responseText.LastIndexOf "Never valid"
+        Assert.NotEqual(idx1, idx2)
+    }
+    
+    [<Fact>]
+    let ``[replace&augment validation: always fail] /test-validation?maxLengthRestrictedTo8String=123456789 -> 400 "Never valid, Never valid'"`` () = task {
+        let client = client (fun s ->
+            s.AddSingleton<SpecWithValidationExtensibility.IGiraffeValidator<_>, AlwaysFailValidationReplacer>()
+             .AddSingleton<SpecWithValidationExtensibility.IGiraffeAdditionalValidator<_>, AlwaysFailValidationAugmenter>())
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=123456789")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
+        do Assert.Contains("Never valid", responseText)
+        let idx1 = responseText.IndexOf "Never valid"
+        let idx2 = responseText.LastIndexOf "Never valid"
+        Assert.NotEqual(idx1, idx2)
+    }
+    
+    [<Fact>]
+    let ``[replace validation: never fail] /test-validation?maxLengthRestrictedTo8String=12345678 -> 200 "ok"`` ()  = task {
+        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeValidator<_>, NeverFailValidationReplacer>())
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=12345678")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal("\"ok\"", responseText)
+        do Assert.Equal(HttpStatusCode.OK, response.StatusCode)
+    }
+    
+    [<Fact>]
+    let ``[replace validation: never fail] /test-validation?maxLengthRestrictedTo8String=123456789 -> 200 "ok"`` () = task {
+        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeValidator<_>, NeverFailValidationReplacer>())
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=123456789")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal("\"ok\"", responseText)
+        do Assert.Equal(HttpStatusCode.OK, response.StatusCode)
+    }
+    
+    [<Fact>]
+    let ``[augment validation: never fail] /test-validation?maxLengthRestrictedTo8String=12345678 -> 200 "ok"`` ()  = task {
+        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeAdditionalValidator<_>, NeverFailValidationAugmenter>())
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=12345678")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal("\"ok\"", responseText)
+        do Assert.Equal(HttpStatusCode.OK, response.StatusCode)
+    }
+    
+    [<Fact>]
+    let ``[augment validation: never fail] /test-validation?maxLengthRestrictedTo8String=123456789 -> 400 "must be a string or array type with a maximum length of '8'"`` () = task {
+        let client = client (fun s -> s.AddSingleton<SpecWithValidationExtensibility.IGiraffeAdditionalValidator<_>, NeverFailValidationAugmenter>())
+        let! response = client.GetAsync("/test-validation?maxLengthRestrictedTo8String=123456789")
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
+        do Assert.Contains("must be a string or array type with a maximum length of '8'", responseText)
+    }

--- a/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationTests.fs
+++ b/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationTests.fs
@@ -682,10 +682,9 @@ type SpecWithValidationTests() =
         let! responseText = response.Content.ReadAsStringAsync()
         let responseText =
             // DataAnnotations.RangeAttribute produces message with ∞ for Infinity on Win10/win-latest/macos-latest.
-            // I assume this behavior is common for other OS from this families.
             // I (@bessgeor) don't think this is a really important difference to work-around in the code generated
             // So here is this ad-hoc and the note in README
-            if Environment.OSVersion.Platform <> PlatformID.Unix then
+            if responseText.Contains "∞" then
                 responseText.Replace("∞", "Infinity")
             else responseText
         let responseJson = JsonConvert.DeserializeObject<SpecWithValidation.validationErrorResponse>(responseText, jsonSettings)

--- a/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationTests.fs
+++ b/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationTests.fs
@@ -356,40 +356,40 @@ module ValidationCases =
                 queryResponse [| "floatBetween8ExclusiveAnd64Exclusive" |] [| "The field floatBetween8ExclusiveAnd64Exclusive must be between 8.00000001 and 63.99999999." |],
                 { x with floatBetween8ExclusiveAnd64Exclusive = 64. }
             """floatGTE8 = 7.99999999 """, fun x ->
-                queryResponse [| "floatGTE8" |] [| "The field floatGTE8 must be between 8 and ∞." |],
+                queryResponse [| "floatGTE8" |] [| "The field floatGTE8 must be between 8 and Infinity." |],
                 { x with floatGTE8 = 7.99999999 }
             """floatGTE8 = Double.MinValue """, fun x ->
-                queryResponse [| "floatGTE8" |] [| "The field floatGTE8 must be between 8 and ∞." |],
+                queryResponse [| "floatGTE8" |] [| "The field floatGTE8 must be between 8 and Infinity." |],
                 { x with floatGTE8 = Double.MinValue }
             """floatGTE8 = Double.NegativeInfinity """, fun x ->
-                queryResponse [| "floatGTE8" |] [| "The field floatGTE8 must be between 8 and ∞." |],
+                queryResponse [| "floatGTE8" |] [| "The field floatGTE8 must be between 8 and Infinity." |],
                 { x with floatGTE8 = Double.NegativeInfinity }
             """floatGT8 = 8. """, fun x ->
-                queryResponse [| "floatGT8" |] [| "The field floatGT8 must be between 8.00000001 and ∞." |],
+                queryResponse [| "floatGT8" |] [| "The field floatGT8 must be between 8.00000001 and Infinity." |],
                 { x with floatGT8 = 8. }
             """floatGT8 = Double.MinValue """, fun x ->
-                queryResponse [| "floatGT8" |] [| "The field floatGT8 must be between 8.00000001 and ∞." |],
+                queryResponse [| "floatGT8" |] [| "The field floatGT8 must be between 8.00000001 and Infinity." |],
                 { x with floatGT8 = Double.MinValue }
             """floatGT8 = Double.NegativeInfinity """, fun x ->
-                queryResponse [| "floatGT8" |] [| "The field floatGT8 must be between 8.00000001 and ∞." |],
+                queryResponse [| "floatGT8" |] [| "The field floatGT8 must be between 8.00000001 and Infinity." |],
                 { x with floatGT8 = Double.NegativeInfinity }
             """floatLTE64 = 64.00000001 """, fun x ->
-                queryResponse [| "floatLTE64" |] [| "The field floatLTE64 must be between -∞ and 64." |],
+                queryResponse [| "floatLTE64" |] [| "The field floatLTE64 must be between -Infinity and 64." |],
                 { x with floatLTE64 = 64.00000001 }
             """floatLTE64 = Double.MaxValue """, fun x ->
-                queryResponse [| "floatLTE64" |] [| "The field floatLTE64 must be between -∞ and 64." |],
+                queryResponse [| "floatLTE64" |] [| "The field floatLTE64 must be between -Infinity and 64." |],
                 { x with floatLTE64 = Double.MaxValue }
             """floatLTE64 = Double.PositiveInfinity """, fun x ->
-                queryResponse [| "floatLTE64" |] [| "The field floatLTE64 must be between -∞ and 64." |],
+                queryResponse [| "floatLTE64" |] [| "The field floatLTE64 must be between -Infinity and 64." |],
                 { x with floatLTE64 = Double.PositiveInfinity }
             """floatLT64 = 64. """, fun x ->
-                queryResponse [| "floatLT64" |] [| "The field floatLT64 must be between -∞ and 63.99999999." |],
+                queryResponse [| "floatLT64" |] [| "The field floatLT64 must be between -Infinity and 63.99999999." |],
                 { x with floatLT64 = 64. }
             """floatLT64 = Double.MaxValue """, fun x ->
-                queryResponse [| "floatLT64" |] [| "The field floatLT64 must be between -∞ and 63.99999999." |],
+                queryResponse [| "floatLT64" |] [| "The field floatLT64 must be between -Infinity and 63.99999999." |],
                 { x with floatLT64 = Double.MaxValue }
             """floatLT64 = Double.PositiveInfinity """, fun x ->
-                queryResponse [| "floatLT64" |] [| "The field floatLT64 must be between -∞ and 63.99999999." |],
+                queryResponse [| "floatLT64" |] [| "The field floatLT64 must be between -Infinity and 63.99999999." |],
                 { x with floatLT64 = Double.PositiveInfinity }
         |]
     let private validQueryVariations = enumerateValidVariations validQuery validQueryForkers
@@ -680,6 +680,14 @@ type SpecWithValidationTests() =
         let url = toUrlString pnq
         let! response = client.PostAsync(url, content)
         let! responseText = response.Content.ReadAsStringAsync()
+        let responseText =
+            // DataAnnotations.RangeAttribute produces message with ∞ for Infinity on Win10.
+            // I assume this is the common MS OS behavior.
+            // I (@bessgeor) don't think this is a really important difference to work-around in the code generated
+            // So here is this ad-hoc and the note in README
+            if Environment.OSVersion.Platform <> PlatformID.Unix && Environment.OSVersion.Platform <> PlatformID.MacOSX then
+                responseText.Replace("∞", "Infinity")
+            else responseText
         let responseJson = JsonConvert.DeserializeObject<SpecWithValidation.validationErrorResponse>(responseText, jsonSettings)
         do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
         do Assert.Equal(err, responseJson)

--- a/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationTests.fs
+++ b/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationTests.fs
@@ -681,11 +681,11 @@ type SpecWithValidationTests() =
         let! response = client.PostAsync(url, content)
         let! responseText = response.Content.ReadAsStringAsync()
         let responseText =
-            // DataAnnotations.RangeAttribute produces message with ∞ for Infinity on Win10.
-            // I assume this is the common MS OS behavior.
+            // DataAnnotations.RangeAttribute produces message with ∞ for Infinity on Win10/win-latest/macos-latest.
+            // I assume this behavior is common for other OS from this families.
             // I (@bessgeor) don't think this is a really important difference to work-around in the code generated
             // So here is this ad-hoc and the note in README
-            if Environment.OSVersion.Platform <> PlatformID.Unix && Environment.OSVersion.Platform <> PlatformID.MacOSX then
+            if Environment.OSVersion.Platform <> PlatformID.Unix then
                 responseText.Replace("∞", "Infinity")
             else responseText
         let responseJson = JsonConvert.DeserializeObject<SpecWithValidation.validationErrorResponse>(responseText, jsonSettings)

--- a/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationTests.fs
+++ b/tests/GiraffeGenerator.IntegrationTests/SpecWithValidationTests.fs
@@ -1,0 +1,686 @@
+﻿namespace GiraffeGenerator.IntegrationTests
+
+open System.Net
+open System.Net.Http
+open System.Text
+open FSharp.Control.Tasks.V2.ContextInsensitive
+open System
+open Giraffe
+open Giraffe.Serialization.Json
+open Microsoft.AspNetCore
+open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Hosting
+open Microsoft.AspNetCore.TestHost
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Logging
+open Newtonsoft.Json
+open Xunit
+
+module ValidationCases =
+    let private enumerateValidVariations valid validForkers =
+        seq {
+            yield "original valid case", valid
+            for desc, forkValid in validForkers do
+                yield desc, forkValid valid
+        }
+        |> Seq.cache
+
+    let private validationResult location path message =
+        let v: SpecWithValidation.validationErrors =
+            {
+                location = location
+                propertyPath = path
+                message = message
+            }
+        v
+    let private response location path messages =
+        let v: SpecWithValidation.validationErrorResponse =
+            {
+                otherErrors = None
+                validationErrors =
+                    messages
+                    |> Array.map (validationResult location path)
+            }
+        v
+
+    let validPath: SpecWithValidation.PostTestValidationPath =
+        { versionEnum = 1; stringOfRestrictedToBeBetween3And8Length = "len" }
+    let private validPathForkers: (string*(SpecWithValidation.PostTestValidationPath -> SpecWithValidation.PostTestValidationPath)) array =
+        [|
+            "versionEnum = 2 ",fun x -> { x with versionEnum = 2 }
+            "versionEnum = 3 ",fun x -> { x with versionEnum = 3 }
+            "stringOfRestrictedToBeBetween3And8Length = \"length 8\" ",fun x -> { x with stringOfRestrictedToBeBetween3And8Length = "length 8" }
+        |]
+    let private pathResponse = response "path"
+    let private invalidPathMakers: (string*(SpecWithValidation.PostTestValidationPath -> struct (SpecWithValidation.validationErrorResponse*SpecWithValidation.PostTestValidationPath))) array =
+        [|
+            """versionEnum = 0 """, fun x ->
+                pathResponse [|"versionEnum"|] [|"The field versionEnum must be a one of ['1', '2', '3']."|],
+                { x with versionEnum = 0 }
+            """versionEnum = 4 """, fun x ->
+                pathResponse [|"versionEnum"|] [|"The field versionEnum must be a one of ['1', '2', '3']."|],
+                { x with versionEnum = 4 }
+            """versionEnum = -1 """, fun x ->
+                pathResponse [|"versionEnum"|] [|"The field versionEnum must be a one of ['1', '2', '3']."|],
+                { x with versionEnum = -1 }
+            """stringOfRestrictedToBeBetween3And8Length = "!?" """, fun x ->
+                pathResponse [| "stringOfRestrictedToBeBetween3And8Length" |] [| "The field stringOfRestrictedToBeBetween3And8Length must be a string or array type with a minimum length of '3'." |],
+                { x with stringOfRestrictedToBeBetween3And8Length = "!?" }
+            (* // path won't match in routing in this cases
+            """stringOfRestrictedToBeBetween3And8Length = "" """, fun x ->
+                pathResponse [| "stringOfRestrictedToBeBetween3And8Length" |] [| "The field stringOfRestrictedToBeBetween3And8Length must be a string or array type with a minimum length of '3'." |],
+                { x with stringOfRestrictedToBeBetween3And8Length = "" }*)
+            """stringOfRestrictedToBeBetween3And8Length = "My length is definitely bigger than 8" """, fun x ->
+                pathResponse [| "stringOfRestrictedToBeBetween3And8Length" |] [| "The field stringOfRestrictedToBeBetween3And8Length must be a string or array type with a maximum length of '8'." |],
+                { x with stringOfRestrictedToBeBetween3And8Length = "My length is definitely bigger than 8" }
+        |]
+    let private validPathVariations = enumerateValidVariations validPath validPathForkers
+
+    let validQuery: SpecWithValidation.PostTestValidationQuery =
+        { maxLengthRestrictedTo8String = "1234"
+          minLengthRestrictedTo3String = "123456"
+          stringOfDDMMMPattern = "15May"
+          stringOfLengthBetween8And64ContainingAGiraffe = "1giraffe2giraffe3giraffe"
+          integerDivisibleBy2 = 8
+          integerBetween8And64 = 8
+          integerBetween8And64Exclusive = 8
+          integerBetween8ExclusiveAnd64 = 9
+          integerBetween8ExclusiveAnd64Exclusive = 9
+          integerGTE8 = 8
+          integerGT8 = 9
+          integerLTE64 = 64
+          integerLT64 = 63
+          integerEQ64 = 64
+          longEnum = 0L
+          longDivisibleBy2 = 8L
+          longBetween8And64 = 8L
+          longBetween8And64Exclusive = 8L
+          longBetween8ExclusiveAnd64 = 9L
+          longBetween8ExclusiveAnd64Exclusive = 9L
+          longGTE8 = 8L
+          longGT8 = 9L
+          longLTE64 = 64L
+          longLT64 = 63L
+          longEQ64 = 64L
+          floatEnum = 3.14
+          floatBetween8And64 = 8.
+          floatBetween8And64Exclusive = 8.
+          floatBetween8ExclusiveAnd64 = 8.00000001
+          floatBetween8ExclusiveAnd64Exclusive = 8.00000001
+          floatGTE8 = 8.
+          floatGT8 = 8.00000001
+          floatLTE64 = 64.
+          floatLT64 = 63.99999999
+          floatEQ64 = 64. }
+    let private validQueryForkers: (string*(SpecWithValidation.PostTestValidationQuery -> SpecWithValidation.PostTestValidationQuery)) array =
+        [|
+            //may not be valid in query string
+            //"maxLengthRestrictedTo8String = \"\" ",fun x -> { x with maxLengthRestrictedTo8String = "" }
+            "maxLengthRestrictedTo8String = \"12345678\" ",fun x -> { x with maxLengthRestrictedTo8String = "12345678" }
+            "minLengthRestrictedTo3String = \"123\" ",fun x -> { x with minLengthRestrictedTo3String = "123" }
+            "stringOfDDMMMPattern = \"01Jan\" ",fun x -> { x with stringOfDDMMMPattern = "01Jan" }
+            "stringOfDDMMMPattern = \"30Feb\" ",fun x -> { x with stringOfDDMMMPattern = "30Feb" }
+            "stringOfDDMMMPattern = \"29Mar\" ",fun x -> { x with stringOfDDMMMPattern = "29Mar" }
+            "stringOfLengthBetween8And64ContainingAGiraffe = \"1giraffe!\" ",fun x -> { x with stringOfLengthBetween8And64ContainingAGiraffe = "1giraffe!" }
+            "stringOfLengthBetween8And64ContainingAGiraffe = \"giraffegiraffegiraffegiraffegiraffegiraffegiraffegiraffegiraffe!\" ",fun x -> { x with stringOfLengthBetween8And64ContainingAGiraffe = "giraffegiraffegiraffegiraffegiraffegiraffegiraffegiraffegiraffe!" }
+            "integerDivisibleBy2 = 0 ",fun x -> { x with integerDivisibleBy2 = 0 }
+            "integerDivisibleBy2 = 2 ",fun x -> { x with integerDivisibleBy2 = 2 }
+            "integerDivisibleBy2 = 2147483646 ",fun x -> { x with integerDivisibleBy2 = 2147483646 }
+            "integerDivisibleBy2 = -2147483648 ",fun x -> { x with integerDivisibleBy2 = -2147483648 }
+            "integerBetween8And64 = 64 ",fun x -> { x with integerBetween8And64 = 64 }
+            "integerBetween8And64Exclusive = 32 ",fun x -> { x with integerBetween8And64Exclusive = 32 }
+            "integerBetween8And64Exclusive = 62 ",fun x -> { x with integerBetween8And64Exclusive = 62 }
+            "integerBetween8ExclusiveAnd64 = 64 ",fun x -> { x with integerBetween8ExclusiveAnd64 = 64 }
+            "integerBetween8ExclusiveAnd64Exclusive = 63 ",fun x -> { x with integerBetween8ExclusiveAnd64Exclusive = 63 }
+            "integerGTE8 = Int32.MaxValue ",fun x -> { x with integerGTE8 = Int32.MaxValue }
+            "integerGT8 = Int32.MaxValue ",fun x -> { x with integerGT8 = Int32.MaxValue }
+            "integerLTE64 = Int32.MinValue ",fun x -> { x with integerLTE64 = Int32.MinValue }
+            "integerLT64 = Int32.MinValue ",fun x -> { x with integerLT64 = Int32.MinValue }
+            "longEnum = Int64.MinValue ",fun x -> { x with longEnum = Int64.MinValue }
+            "longEnum = Int64.MaxValue ",fun x -> { x with longEnum = Int64.MaxValue }
+            "longDivisibleBy2 = 0L ",fun x -> { x with longDivisibleBy2 = 0L }
+            "longDivisibleBy2 = 2L ",fun x -> { x with longDivisibleBy2 = 2L }
+            "longDivisibleBy2 = -9223372036854775806L ",fun x -> { x with longDivisibleBy2 = -9223372036854775806L }
+            "longDivisibleBy2 = -9223372036854775808L ",fun x -> { x with longDivisibleBy2 = -9223372036854775808L }
+            "longBetween8And64 = 64L ",fun x -> { x with longBetween8And64 = 64L }
+            "longBetween8And64Exclusive = 63L ",fun x -> { x with longBetween8And64Exclusive = 63L }
+            "longBetween8ExclusiveAnd64 = 64L ",fun x -> { x with longBetween8ExclusiveAnd64 = 64L }
+            "longBetween8ExclusiveAnd64Exclusive = 63L ",fun x -> { x with longBetween8ExclusiveAnd64Exclusive = 63L }
+            "longGTE8 = Int64.MaxValue ",fun x -> { x with longGTE8 = Int64.MaxValue }
+            "longGT8 = Int64.MaxValue ",fun x -> { x with longGT8 = Int64.MaxValue }
+            "longLTE64 = Int64.MinValue ",fun x -> { x with longLTE64 = Int64.MinValue }
+            "longLT64 = Int64.MinValue ",fun x -> { x with longLT64 = Int64.MinValue }
+            "floatEnum = 3.141 ",fun x -> { x with floatEnum = 3.141 }
+            "floatEnum = 3.1415 ",fun x -> { x with floatEnum = 3.1415 }
+            "floatEnum = 3.14159 ",fun x -> { x with floatEnum = 3.14159 }
+            "floatEnum = 3.141592 ",fun x -> { x with floatEnum = 3.141592 }
+            "floatBetween8And64 = 8.00000001 ",fun x -> { x with floatBetween8And64 = 8.00000001 }
+            "floatBetween8And64 = 63.999999999 ",fun x -> { x with floatBetween8And64 = 63.999999999 }
+            "floatBetween8And64 = 64. ",fun x -> { x with floatBetween8And64 = 64. }
+            "floatBetween8And64Exclusive = 8.00000001 ",fun x -> { x with floatBetween8And64Exclusive = 8.00000001 }
+            "floatBetween8And64Exclusive = 63.99999999 ",fun x -> { x with floatBetween8And64Exclusive = 63.99999999 }
+            "floatBetween8ExclusiveAnd64 = 9.00000001 ",fun x -> { x with floatBetween8ExclusiveAnd64 = 9.00000001 }
+            "floatBetween8ExclusiveAnd64 = 63.99999999 ",fun x -> { x with floatBetween8ExclusiveAnd64 = 63.99999999 }
+            "floatBetween8ExclusiveAnd64 = 64. ",fun x -> { x with floatBetween8ExclusiveAnd64 = 64. }
+            "floatGTE8 = Double.MaxValue ",fun x -> { x with floatGTE8 = Double.MaxValue }
+            "floatGTE8 = Double.PositiveInfinity ",fun x -> { x with floatGTE8 = Double.PositiveInfinity }
+            "floatGT8 = Double.MaxValue ",fun x -> { x with floatGT8 = Double.MaxValue }
+            "floatGT8 = Double.PositiveInfinity ",fun x -> { x with floatGT8 = Double.PositiveInfinity }
+            "floatLTE64 = Double.MinValue ",fun x -> { x with floatLTE64 = Double.MinValue }
+            "floatLTE64 = Double.NegativeInfinity ",fun x -> { x with floatLTE64 = Double.NegativeInfinity }
+            "floatLT64 = Double.MinValue ",fun x -> { x with floatLT64 = Double.MinValue }
+            "floatLT64 = Double.NegativeInfinity ",fun x -> { x with floatLT64 = Double.NegativeInfinity }
+        |]
+    let private queryResponse = response "query"
+    let private invalidQueryMakers: (string*(SpecWithValidation.PostTestValidationQuery -> struct(SpecWithValidation.validationErrorResponse*SpecWithValidation.PostTestValidationQuery))) array =
+        [|
+            """maxLengthRestrictedTo8String = "I am too long" """, fun x ->
+                queryResponse [| "maxLengthRestrictedTo8String" |] [| "The field maxLengthRestrictedTo8String must be a string or array type with a maximum length of '8'." |],
+                { x with maxLengthRestrictedTo8String = "I am too long" }
+            """minLengthRestrictedTo3String = "!?" """, fun x ->
+                queryResponse [| "minLengthRestrictedTo3String" |] [| "The field minLengthRestrictedTo3String must be a string or array type with a minimum length of '3'." |],
+                { x with minLengthRestrictedTo3String = "!?" }
+            """stringOfDDMMMPattern = "-1Feb" """, fun x ->
+                queryResponse [| "stringOfDDMMMPattern" |] [| "The field stringOfDDMMMPattern must match the regular expression '^((3[0-1])|([0-2]?[0-9]))(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov)$'." |],
+                { x with stringOfDDMMMPattern = "-1Feb" }
+            """stringOfDDMMMPattern = "34Mar" """, fun x ->
+                queryResponse [| "stringOfDDMMMPattern" |] [| "The field stringOfDDMMMPattern must match the regular expression '^((3[0-1])|([0-2]?[0-9]))(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov)$'." |],
+                { x with stringOfDDMMMPattern = "34Mar" }
+            """stringOfDDMMMPattern = "30Spartans" """, fun x ->
+                queryResponse [| "stringOfDDMMMPattern" |] [| "The field stringOfDDMMMPattern must match the regular expression '^((3[0-1])|([0-2]?[0-9]))(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov)$'." |],
+                { x with stringOfDDMMMPattern = "30Spartans" }
+            """stringOfLengthBetween8And64ContainingAGiraffe = "Short!" """, fun x ->
+                queryResponse [| "stringOfLengthBetween8And64ContainingAGiraffe" |]
+                    [| "The field stringOfLengthBetween8And64ContainingAGiraffe must be a string or array type with a minimum length of '8'."
+                       "The field stringOfLengthBetween8And64ContainingAGiraffe must match the regular expression 'giraffe'." |],
+                { x with stringOfLengthBetween8And64ContainingAGiraffe = "Short!" }
+            """stringOfLengthBetween8And64ContainingAGiraffe = "giraffe" """, fun x ->
+                queryResponse [| "stringOfLengthBetween8And64ContainingAGiraffe" |] [| "The field stringOfLengthBetween8And64ContainingAGiraffe must be a string or array type with a minimum length of '8'." |],
+                { x with stringOfLengthBetween8And64ContainingAGiraffe = "giraffe" }
+            """stringOfLengthBetween8And64ContainingAGiraffe = "Not a Giraffe because of case sensitivity" """, fun x ->
+                queryResponse [| "stringOfLengthBetween8And64ContainingAGiraffe" |] [| "The field stringOfLengthBetween8And64ContainingAGiraffe must match the regular expression 'giraffe'." |],
+                { x with stringOfLengthBetween8And64ContainingAGiraffe = "Not a Giraffe because of case sensitivity" }
+            """stringOfLengthBetween8And64ContainingAGiraffe = "giraffegiraffegiraffegiraffegiraffegiraffegiraffegiraffegiraffegiraffe" """, fun x ->
+                queryResponse [| "stringOfLengthBetween8And64ContainingAGiraffe" |] [| "The field stringOfLengthBetween8And64ContainingAGiraffe must be a string or array type with a maximum length of '64'." |],
+                { x with stringOfLengthBetween8And64ContainingAGiraffe = "giraffegiraffegiraffegiraffegiraffegiraffegiraffegiraffegiraffegiraffe" }
+            """stringOfLengthBetween8And64ContainingAGiraffe = "This text describes a long-necked animal of ochre color with brown spots" """, fun x ->
+                queryResponse [| "stringOfLengthBetween8And64ContainingAGiraffe" |]
+                    [| "The field stringOfLengthBetween8And64ContainingAGiraffe must be a string or array type with a maximum length of '64'."
+                       "The field stringOfLengthBetween8And64ContainingAGiraffe must match the regular expression 'giraffe'." |],
+                { x with stringOfLengthBetween8And64ContainingAGiraffe = "This text describes a long-necked animal of ochre color with brown spots" }
+            """integerDivisibleBy2 = 1 """, fun x ->
+                queryResponse [| "integerDivisibleBy2" |] [| "The field integerDivisibleBy2 must be a multiple of 2." |],
+                { x with integerDivisibleBy2 = 1 }
+            """integerDivisibleBy2 = -1 """, fun x ->
+                queryResponse [| "integerDivisibleBy2" |] [| "The field integerDivisibleBy2 must be a multiple of 2." |],
+                { x with integerDivisibleBy2 = -1 }
+            """integerBetween8And64 = 7 """, fun x ->
+                queryResponse [| "integerBetween8And64" |] [| "The field integerBetween8And64 must be between 8 and 64." |],
+                { x with integerBetween8And64 = 7 }
+            """integerBetween8And64 = 65 """, fun x ->
+                queryResponse [| "integerBetween8And64" |] [| "The field integerBetween8And64 must be between 8 and 64." |],
+                { x with integerBetween8And64 = 65 }
+            """integerBetween8And64Exclusive = 7 """, fun x ->
+                queryResponse [| "integerBetween8And64Exclusive" |] [| "The field integerBetween8And64Exclusive must be between 8 and 63." |],
+                { x with integerBetween8And64Exclusive = 7 }
+            """integerBetween8And64Exclusive = 64 """, fun x ->
+                queryResponse [| "integerBetween8And64Exclusive" |] [| "The field integerBetween8And64Exclusive must be between 8 and 63." |],
+                { x with integerBetween8And64Exclusive = 64 }
+            """integerBetween8ExclusiveAnd64 = 8 """, fun x ->
+                queryResponse [| "integerBetween8ExclusiveAnd64" |] [| "The field integerBetween8ExclusiveAnd64 must be between 9 and 64." |],
+                { x with integerBetween8ExclusiveAnd64 = 8 }
+            """integerBetween8ExclusiveAnd64 = 65 """, fun x ->
+                queryResponse [| "integerBetween8ExclusiveAnd64" |] [| "The field integerBetween8ExclusiveAnd64 must be between 9 and 64." |],
+                { x with integerBetween8ExclusiveAnd64 = 65 }
+            """integerBetween8ExclusiveAnd64Exclusive = 8 """, fun x ->
+                queryResponse [| "integerBetween8ExclusiveAnd64Exclusive" |] [| "The field integerBetween8ExclusiveAnd64Exclusive must be between 9 and 63." |],
+                { x with integerBetween8ExclusiveAnd64Exclusive = 8 }
+            """integerBetween8ExclusiveAnd64Exclusive = 64 """, fun x ->
+                queryResponse [| "integerBetween8ExclusiveAnd64Exclusive" |] [| "The field integerBetween8ExclusiveAnd64Exclusive must be between 9 and 63." |],
+                { x with integerBetween8ExclusiveAnd64Exclusive = 64 }
+            """integerGTE8 = 7 """, fun x ->
+                queryResponse [| "integerGTE8" |] [| "The field integerGTE8 must be between 8 and 2147483647." |],
+                { x with integerGTE8 = 7 }
+            """integerGTE8 = Int32.MinValue """, fun x ->
+                queryResponse [| "integerGTE8" |] [| "The field integerGTE8 must be between 8 and 2147483647." |],
+                { x with integerGTE8 = Int32.MinValue }
+            """integerGT8 = 8 """, fun x ->
+                queryResponse [| "integerGT8" |] [| "The field integerGT8 must be between 9 and 2147483647." |],
+                { x with integerGT8 = 8 }
+            """integerGT8 = Int32.MinValue """, fun x ->
+                queryResponse [| "integerGT8" |] [| "The field integerGT8 must be between 9 and 2147483647." |],
+                { x with integerGT8 = Int32.MinValue }
+            """integerLTE64 = 65 """, fun x ->
+                queryResponse [| "integerLTE64" |] [| "The field integerLTE64 must be between -2147483648 and 64." |],
+                { x with integerLTE64 = 65 }
+            """integerLTE64 = Int32.MaxValue """, fun x ->
+                queryResponse [| "integerLTE64" |] [| "The field integerLTE64 must be between -2147483648 and 64." |],
+                { x with integerLTE64 = Int32.MaxValue }
+            """integerLT64 = 64 """, fun x ->
+                queryResponse [| "integerLT64" |] [| "The field integerLT64 must be between -2147483648 and 63." |],
+                { x with integerLT64 = 64 }
+            """integerLT64 = Int32.MaxValue """, fun x ->
+                queryResponse [| "integerLT64" |] [| "The field integerLT64 must be between -2147483648 and 63." |],
+                { x with integerLT64 = Int32.MaxValue }
+            """longEnum = -1L """, fun x ->
+                queryResponse [| "longEnum" |] [| "The field longEnum must be a one of ['-9223372036854775808', '0', '9223372036854775807']." |],
+                { x with longEnum = -1L }
+            """longEnum = 1L """, fun x ->
+                queryResponse [| "longEnum" |] [| "The field longEnum must be a one of ['-9223372036854775808', '0', '9223372036854775807']." |],
+                { x with longEnum = 1L }
+            """longDivisibleBy2 = 1L """, fun x ->
+                queryResponse [| "longDivisibleBy2" |] [| "The field longDivisibleBy2 must be a multiple of 2." |],
+                { x with longDivisibleBy2 = 1L }
+            """longDivisibleBy2 = -1L """, fun x ->
+                queryResponse [| "longDivisibleBy2" |] [| "The field longDivisibleBy2 must be a multiple of 2." |],
+                { x with longDivisibleBy2 = -1L }
+            """longBetween8And64 = 7L """, fun x ->
+                queryResponse [| "longBetween8And64" |] [| "The field longBetween8And64 must be between 8 and 64." |],
+                { x with longBetween8And64 = 7L }
+            """longBetween8And64 = 65L """, fun x ->
+                queryResponse [| "longBetween8And64" |] [| "The field longBetween8And64 must be between 8 and 64." |],
+                { x with longBetween8And64 = 65L }
+            """longBetween8And64Exclusive = 7L """, fun x ->
+                queryResponse [| "longBetween8And64Exclusive" |] [| "The field longBetween8And64Exclusive must be between 8 and 63." |],
+                { x with longBetween8And64Exclusive = 7L }
+            """longBetween8And64Exclusive = 64L """, fun x ->
+                queryResponse [| "longBetween8And64Exclusive" |] [| "The field longBetween8And64Exclusive must be between 8 and 63." |],
+                { x with longBetween8And64Exclusive = 64L }
+            """longBetween8ExclusiveAnd64 = 8L """, fun x ->
+                queryResponse [| "longBetween8ExclusiveAnd64" |] [| "The field longBetween8ExclusiveAnd64 must be between 9 and 64." |],
+                { x with longBetween8ExclusiveAnd64 = 8L }
+            """longBetween8ExclusiveAnd64 = 65L """, fun x ->
+                queryResponse [| "longBetween8ExclusiveAnd64" |] [| "The field longBetween8ExclusiveAnd64 must be between 9 and 64." |],
+                { x with longBetween8ExclusiveAnd64 = 65L }
+            """longBetween8ExclusiveAnd64Exclusive = 8L """, fun x ->
+                queryResponse [| "longBetween8ExclusiveAnd64Exclusive" |] [| "The field longBetween8ExclusiveAnd64Exclusive must be between 9 and 63." |],
+                { x with longBetween8ExclusiveAnd64Exclusive = 8L }
+            """longBetween8ExclusiveAnd64Exclusive = 64L """, fun x ->
+                queryResponse [| "longBetween8ExclusiveAnd64Exclusive" |] [| "The field longBetween8ExclusiveAnd64Exclusive must be between 9 and 63." |],
+                { x with longBetween8ExclusiveAnd64Exclusive = 64L }
+            """longGTE8 = 7L """, fun x ->
+                queryResponse [| "longGTE8" |] [| "The field longGTE8 must be between 8 and 9223372036854775807." |],
+                { x with longGTE8 = 7L }
+            """longGTE8 = Int64.MinValue """, fun x ->
+                queryResponse [| "longGTE8" |] [| "The field longGTE8 must be between 8 and 9223372036854775807." |],
+                { x with longGTE8 = Int64.MinValue }
+            """longGT8 = 8L """, fun x ->
+                queryResponse [| "longGT8" |] [| "The field longGT8 must be between 9 and 9223372036854775807." |],
+                { x with longGT8 = 8L }
+            """longGT8 = Int64.MinValue """, fun x ->
+                queryResponse [| "longGT8" |] [| "The field longGT8 must be between 9 and 9223372036854775807." |],
+                { x with longGT8 = Int64.MinValue }
+            """longLTE64 = 65L """, fun x ->
+                queryResponse [| "longLTE64" |] [| "The field longLTE64 must be between -9223372036854775808 and 64." |],
+                { x with longLTE64 = 65L }
+            """longLTE64 = Int64.MaxValue """, fun x ->
+                queryResponse [| "longLTE64" |] [| "The field longLTE64 must be between -9223372036854775808 and 64." |],
+                { x with longLTE64 = Int64.MaxValue }
+            """longLT64 = 64L """, fun x ->
+                queryResponse [| "longLT64" |] [| "The field longLT64 must be between -9223372036854775808 and 63." |],
+                { x with longLT64 = 64L }
+            """longLT64 = Int64.MaxValue """, fun x ->
+                queryResponse [| "longLT64" |] [| "The field longLT64 must be between -9223372036854775808 and 63." |],
+                { x with longLT64 = Int64.MaxValue }
+            """floatEnum = 3.1415921 """, fun x ->
+                queryResponse [| "floatEnum" |] [| "The field floatEnum must be a one of ['3.14', '3.141', '3.1415', '3.14159', '3.141592']." |],
+                { x with floatEnum = 3.1415921 }
+            """floatEnum = 3. """, fun x ->
+                queryResponse [| "floatEnum" |] [| "The field floatEnum must be a one of ['3.14', '3.141', '3.1415', '3.14159', '3.141592']." |],
+                { x with floatEnum = 3. }
+            """floatEnum = 4. """, fun x ->
+                queryResponse [| "floatEnum" |] [| "The field floatEnum must be a one of ['3.14', '3.141', '3.1415', '3.14159', '3.141592']." |],
+                { x with floatEnum = 4. }
+            """floatBetween8And64 = 7.99999999 """, fun x ->
+                queryResponse [| "floatBetween8And64" |] [| "The field floatBetween8And64 must be between 8 and 64." |],
+                { x with floatBetween8And64 = 7.99999999 }
+            """floatBetween8And64 = 64.00000001 """, fun x ->
+                queryResponse [| "floatBetween8And64" |] [| "The field floatBetween8And64 must be between 8 and 64." |],
+                { x with floatBetween8And64 = 64.00000001 }
+            """floatBetween8And64Exclusive = 7.99999999 """, fun x ->
+                queryResponse [| "floatBetween8And64Exclusive" |] [| "The field floatBetween8And64Exclusive must be between 8 and 63.99999999." |],
+                { x with floatBetween8And64Exclusive = 7.99999999 }
+            """floatBetween8And64Exclusive = 64. """, fun x ->
+                queryResponse [| "floatBetween8And64Exclusive" |] [| "The field floatBetween8And64Exclusive must be between 8 and 63.99999999." |],
+                { x with floatBetween8And64Exclusive = 64. }
+            """floatBetween8ExclusiveAnd64 = 8. """, fun x ->
+                queryResponse [| "floatBetween8ExclusiveAnd64" |] [| "The field floatBetween8ExclusiveAnd64 must be between 8.00000001 and 64." |],
+                { x with floatBetween8ExclusiveAnd64 = 8. }
+            """floatBetween8ExclusiveAnd64 = 64.00000001 """, fun x ->
+                queryResponse [| "floatBetween8ExclusiveAnd64" |] [| "The field floatBetween8ExclusiveAnd64 must be between 8.00000001 and 64." |],
+                { x with floatBetween8ExclusiveAnd64 = 64.00000001 }
+            """floatBetween8ExclusiveAnd64Exclusive = 8. """, fun x ->
+                queryResponse [| "floatBetween8ExclusiveAnd64Exclusive" |] [| "The field floatBetween8ExclusiveAnd64Exclusive must be between 8.00000001 and 63.99999999." |],
+                { x with floatBetween8ExclusiveAnd64Exclusive = 8. }
+            """floatBetween8ExclusiveAnd64Exclusive = 64. """, fun x ->
+                queryResponse [| "floatBetween8ExclusiveAnd64Exclusive" |] [| "The field floatBetween8ExclusiveAnd64Exclusive must be between 8.00000001 and 63.99999999." |],
+                { x with floatBetween8ExclusiveAnd64Exclusive = 64. }
+            """floatGTE8 = 7.99999999 """, fun x ->
+                queryResponse [| "floatGTE8" |] [| "The field floatGTE8 must be between 8 and ∞." |],
+                { x with floatGTE8 = 7.99999999 }
+            """floatGTE8 = Double.MinValue """, fun x ->
+                queryResponse [| "floatGTE8" |] [| "The field floatGTE8 must be between 8 and ∞." |],
+                { x with floatGTE8 = Double.MinValue }
+            """floatGTE8 = Double.NegativeInfinity """, fun x ->
+                queryResponse [| "floatGTE8" |] [| "The field floatGTE8 must be between 8 and ∞." |],
+                { x with floatGTE8 = Double.NegativeInfinity }
+            """floatGT8 = 8. """, fun x ->
+                queryResponse [| "floatGT8" |] [| "The field floatGT8 must be between 8.00000001 and ∞." |],
+                { x with floatGT8 = 8. }
+            """floatGT8 = Double.MinValue """, fun x ->
+                queryResponse [| "floatGT8" |] [| "The field floatGT8 must be between 8.00000001 and ∞." |],
+                { x with floatGT8 = Double.MinValue }
+            """floatGT8 = Double.NegativeInfinity """, fun x ->
+                queryResponse [| "floatGT8" |] [| "The field floatGT8 must be between 8.00000001 and ∞." |],
+                { x with floatGT8 = Double.NegativeInfinity }
+            """floatLTE64 = 64.00000001 """, fun x ->
+                queryResponse [| "floatLTE64" |] [| "The field floatLTE64 must be between -∞ and 64." |],
+                { x with floatLTE64 = 64.00000001 }
+            """floatLTE64 = Double.MaxValue """, fun x ->
+                queryResponse [| "floatLTE64" |] [| "The field floatLTE64 must be between -∞ and 64." |],
+                { x with floatLTE64 = Double.MaxValue }
+            """floatLTE64 = Double.PositiveInfinity """, fun x ->
+                queryResponse [| "floatLTE64" |] [| "The field floatLTE64 must be between -∞ and 64." |],
+                { x with floatLTE64 = Double.PositiveInfinity }
+            """floatLT64 = 64. """, fun x ->
+                queryResponse [| "floatLT64" |] [| "The field floatLT64 must be between -∞ and 63.99999999." |],
+                { x with floatLT64 = 64. }
+            """floatLT64 = Double.MaxValue """, fun x ->
+                queryResponse [| "floatLT64" |] [| "The field floatLT64 must be between -∞ and 63.99999999." |],
+                { x with floatLT64 = Double.MaxValue }
+            """floatLT64 = Double.PositiveInfinity """, fun x ->
+                queryResponse [| "floatLT64" |] [| "The field floatLT64 must be between -∞ and 63.99999999." |],
+                { x with floatLT64 = Double.PositiveInfinity }
+        |]
+    let private validQueryVariations = enumerateValidVariations validQuery validQueryForkers
+
+    let private validNestedValidationObjectOfIntGTE2: SpecWithValidation.nestedValidationObjectOfIntGTE2 =
+        {
+            nestedIntGT2 = 32
+        }
+    let private validDeeplyNestedValidation: SpecWithValidation.deeplyNestedValidation =
+        {
+            intGTE2ObjectOption =
+                Some {
+                    intGTE2Option = Some 32
+                }
+        }
+
+    let validBody: SpecWithValidation.TestValidationPostBodyJson=
+        {
+            arrayOf2To4UniqueItems = [|1;2;3|]
+            arrayOf2To4Items = [|1;2;3|]
+            arrayOptionOfMinimum2Items = Some [|1;2|]
+            arrayOfMaximum4Items = [|1;2|]
+            nestedValidationArrayOfIntGTE2 = [|5;6;7|]
+            nestedValidationObjectOfIntGTE2 = validNestedValidationObjectOfIntGTE2
+            nestedValidationOptionOfIntGTE2 = Some 32
+            deeplyNestedValidation =  Some [| [| validDeeplyNestedValidation |] |]
+        }
+    let private validBodyForkers: (string*(SpecWithValidation.TestValidationPostBodyJson -> SpecWithValidation.TestValidationPostBodyJson)) array =
+        [|
+            "arrayOf2To4Items = [|2;2|] ",fun x -> { x with arrayOf2To4Items = [|2;2|] }
+            "arrayOf2To4Items = [|2;2;2;2|] ",fun x -> { x with arrayOf2To4Items = [|2;2;2;2|] }
+            "arrayOfMinimum2Items = None ",fun x -> { x with arrayOptionOfMinimum2Items = None }
+            "arrayOfMaximum4Items = [||] ",fun x -> { x with arrayOfMaximum4Items = [||] }
+            "arrayOfMaximum4Items = [|1;2;3;4|] ",fun x -> { x with arrayOfMaximum4Items = [|1;2;3;4|] }
+            "nestedValidationArrayOfIntGTE2 = [|2;2;2|] ",fun x -> { x with nestedValidationArrayOfIntGTE2 = [|2;2;2|] }
+            "nestedValidationObjectOfIntGTE2 = { validNestedValidationObjectOfIntGTE2 with nestedIntGT2 = 3 } ",fun x -> { x with nestedValidationObjectOfIntGTE2 = { validNestedValidationObjectOfIntGTE2 with nestedIntGT2 = 3 } }
+            "nestedValidationOptionOfIntGTE2 = None ",fun x -> { x with nestedValidationOptionOfIntGTE2 = None }
+            "nestedValidationOptionOfIntGTE2 = Some 2 ",fun x -> { x with nestedValidationOptionOfIntGTE2 = Some 2 }
+            "deeplyNestedValidation = None ",fun x -> { x with deeplyNestedValidation = None }
+            "deeplyNestedValidation = Some [| [| { validDeeplyNestedValidation with intGTE2ObjectOption = None } |] |] ",
+            fun x -> { x with deeplyNestedValidation = Some [| [| { validDeeplyNestedValidation with intGTE2ObjectOption = None } |] |] }
+            "deeplyNestedValidation = Some [| [| { validDeeplyNestedValidation with intGTE2ObjectOption = Some { intGTE2Option = None } } |] |] ",
+            fun x -> { x with deeplyNestedValidation = Some [| [| { validDeeplyNestedValidation with intGTE2ObjectOption = Some { intGTE2Option = None } } |] |] }
+            "deeplyNestedValidation = Some [| [| { validDeeplyNestedValidation with intGTE2ObjectOption = Some { intGTE2Option = Some 2 } } |] |] ",
+            fun x -> { x with deeplyNestedValidation = Some [| [| { validDeeplyNestedValidation with intGTE2ObjectOption = Some { intGTE2Option = Some 2 } } |] |] }
+            "deeplyNestedValidation = Some [| [| { validDeeplyNestedValidation with intGTE2ObjectOption = Some { intGTE2Option = Some 2 } } |]; [||] |] ",
+            fun x -> { x with deeplyNestedValidation = Some [| [| { validDeeplyNestedValidation with intGTE2ObjectOption = Some { intGTE2Option = Some 2 } } |]; [||] |] }
+        |]
+    let private bodyResponse = response "body"
+    let private bodyResponseMultipleProperty messages =
+        let v: SpecWithValidation.validationErrorResponse =
+            {
+                otherErrors = None
+                validationErrors =
+                    messages
+                    |> Array.map (fun (prop, msg) -> validationResult "body" [|prop|] msg)
+            }
+        v
+    let private invalidBodyMakers: (string*(SpecWithValidation.TestValidationPostBodyJson -> struct (SpecWithValidation.validationErrorResponse*SpecWithValidation.TestValidationPostBodyJson))) array =
+        [|
+            """arrayOf2To4UniqueItems = [|1;1;1|] """, fun x ->
+                bodyResponse [| "arrayOf2To4UniqueItems" |] [| "The field arrayOf2To4UniqueItems must contain only unique items." |],
+                { x with arrayOf2To4UniqueItems = [|1;1;1|] }
+            """arrayOf2To4UniqueItems = [|1;2;1;2;1;2|] """, fun x ->
+                bodyResponse [| "arrayOf2To4UniqueItems" |]
+                    [|
+                        "The field arrayOf2To4UniqueItems must be a string or array type with a maximum length of '4'."
+                        "The field arrayOf2To4UniqueItems must contain only unique items."
+                    |],
+                { x with arrayOf2To4UniqueItems = [|1;2;1;2;1;2|] }
+            """arrayOf2To4Items = [||] """, fun x ->
+                bodyResponse [| "arrayOf2To4Items" |] [| "The field arrayOf2To4Items must be a string or array type with a minimum length of '2'." |],
+                { x with arrayOf2To4Items = [||] }
+            """arrayOf2To4Items = [|1|] """, fun x ->
+                bodyResponse [| "arrayOf2To4Items" |] [| "The field arrayOf2To4Items must be a string or array type with a minimum length of '2'." |],
+                { x with arrayOf2To4Items = [|1|] }
+            """arrayOf2To4Items = [|1;2;3;4;5|] """, fun x ->
+                bodyResponse [| "arrayOf2To4Items" |] [| "The field arrayOf2To4Items must be a string or array type with a maximum length of '4'." |],
+                { x with arrayOf2To4Items = [|1;2;3;4;5|] }
+            """arrayOfMaximum4Items = [|1;2;3;4;5;6|] """, fun x ->
+                bodyResponse [| "arrayOfMaximum4Items" |] [| "The field arrayOfMaximum4Items must be a string or array type with a maximum length of '4'." |],
+                { x with arrayOfMaximum4Items = [|1;2;3;4;5;6|] }
+            """arrayOptionOfMinimum2Items = Some [||] """, fun x ->
+                bodyResponse [| "arrayOptionOfMinimum2Items.Value" |] [| "The field arrayOptionOfMinimum2Items.Value must be a string or array type with a minimum length of '2'." |],
+                { x with arrayOptionOfMinimum2Items = Some [||] }
+            """arrayOptionOfMinimum2Items = Some [|1|] """, fun x ->
+                bodyResponse [| "arrayOptionOfMinimum2Items.Value" |] [| "The field arrayOptionOfMinimum2Items.Value must be a string or array type with a minimum length of '2'." |],
+                { x with arrayOptionOfMinimum2Items = Some [|1|] }
+            """nestedValidationArrayOfIntGTE2 = [|1;2;2|] """, fun x ->
+                bodyResponse [| "nestedValidationArrayOfIntGTE2[0]" |] [| "The field nestedValidationArrayOfIntGTE2[0] must be between 2 and 2147483647." |],
+                { x with nestedValidationArrayOfIntGTE2 = [|1;2;2|] }
+            """nestedValidationArrayOfIntGTE2 = [|2;1;2|] """, fun x ->
+                bodyResponseMultipleProperty
+                    [|
+                        "nestedValidationArrayOfIntGTE2[1]", "The field nestedValidationArrayOfIntGTE2[1] must be between 2 and 2147483647."
+                        "nestedValidationArrayOfIntGTE2[2]", "The field nestedValidationArrayOfIntGTE2[2] must be between 2 and 2147483647."
+                    |],
+                { x with nestedValidationArrayOfIntGTE2 = [|2;1;1|] }
+            """nestedValidationObjectOfIntGTE2 = { validNestedValidationObjectOfIntGTE2 with nestedIntGT2 = 1 } """, fun x ->
+                bodyResponse [| "nestedIntGT2" |] [| "The field nestedIntGT2 must be between 2 and 2147483647." |],
+                { x with nestedValidationObjectOfIntGTE2 = { validNestedValidationObjectOfIntGTE2 with nestedIntGT2 = 1 } }
+            """nestedValidationOptionOfIntGTE2 = Some 1 """, fun x ->
+                bodyResponse [| "nestedValidationOptionOfIntGTE2.Value" |] [| "The field nestedValidationOptionOfIntGTE2.Value must be between 2 and 2147483647." |],
+                { x with nestedValidationOptionOfIntGTE2 = Some 1 }
+            """deeplyNestedValidation = Some [| [| validDeeplyNestedValidation; validDeeplyNestedValidation |] |] """, fun x ->
+                bodyResponse [| "deeplyNestedValidation.Value[0]" |] [| "The field deeplyNestedValidation.Value[0] must contain only unique items." |],
+                { x with deeplyNestedValidation = Some [| [| validDeeplyNestedValidation; validDeeplyNestedValidation |] |] }
+            """deeplyNestedValidation = Some [| [| { validDeeplyNestedValidation with intGTE2ObjectOption = Some { intGTE2Option = Some 0 } } |] |] """, fun x ->
+                bodyResponse [| "intGTE2Option.Value" |] [| "The field intGTE2Option.Value must be between 2 and 2147483647." |],
+                { x with deeplyNestedValidation = Some [| [| { validDeeplyNestedValidation with intGTE2ObjectOption = Some { intGTE2Option = Some 0 } } |] |] }
+            """deeplyNestedValidation = Some [| [| nonUniqueInvalidItem; nonUniqueInvalidItem |]; [| validItem; invalidItem |] |]""", fun x ->
+                bodyResponseMultipleProperty
+                    [|
+                        "deeplyNestedValidation.Value[0]", "The field deeplyNestedValidation.Value[0] must contain only unique items."
+                        "intGTE2Option.Value", "The field intGTE2Option.Value must be between 2 and 2147483647."
+                        "intGTE2Option.Value", "The field intGTE2Option.Value must be between 2 and 2147483647."
+                        "intGTE2Option.Value", "The field intGTE2Option.Value must be between 2 and 2147483647."
+                    |],
+                { x with deeplyNestedValidation = Some [|
+                        [|
+                            { validDeeplyNestedValidation with intGTE2ObjectOption = Some { intGTE2Option = Some 0 } }
+                            { validDeeplyNestedValidation with intGTE2ObjectOption = Some { intGTE2Option = Some 0 } }
+                        |]
+                        [|
+                            validDeeplyNestedValidation
+                            { validDeeplyNestedValidation with intGTE2ObjectOption = Some { intGTE2Option = Some 0 } }
+                        |]
+                    |] }
+        |]
+    let private validBodyVariations = enumerateValidVariations validBody validBodyForkers
+
+    let private mergeExpectedResults (a: SpecWithValidation.validationErrorResponse) (b: SpecWithValidation.validationErrorResponse) =
+        let v: SpecWithValidation.validationErrorResponse =
+            {
+                otherErrors = None
+                validationErrors = Array.append a.validationErrors b.validationErrors
+            }
+        v
+    
+    let allValidCases =
+        let make description body path query = [| box description; box body; box (path, query) |]
+        [|
+            for desc, body in validBodyVariations do
+                make desc body validPath validQuery
+            for desc, path in validPathVariations do
+                make desc validBody path validQuery
+            for desc, query in validQueryVariations do
+                make desc validBody validPath query
+        |] |> Array.sortBy (Array.head >> unbox<string>)
+    let allInvalidCases =
+        let make desc body path query err = [| box desc; box body; box (path, query); err |]
+        [|
+            for desc, makeInvalid in invalidBodyMakers do
+                let struct (err, body) = makeInvalid validBody
+                make desc body validPath validQuery err
+            for desc, makeInvalid in invalidPathMakers do
+                let struct (err, path) = makeInvalid validPath
+                make desc validBody path validQuery err
+            for desc, makeInvalid in invalidQueryMakers do
+                let struct (err, query) = makeInvalid validQuery
+                make desc validBody validPath query err
+        |] |> Array.sortBy (Array.head >> unbox<string>)
+
+type InvalidCasesEnumerator() = 
+    interface seq<obj []> with
+        member this.GetEnumerator() = (Seq.ofArray ValidationCases.allInvalidCases).GetEnumerator()
+        member this.GetEnumerator() = 
+            ValidationCases.allInvalidCases.GetEnumerator()
+
+type ValidCasesEnumerator() = 
+    interface seq<obj []> with
+        member this.GetEnumerator() = (Seq.ofArray ValidationCases.allValidCases).GetEnumerator()
+        member this.GetEnumerator() = 
+            ValidationCases.allValidCases.GetEnumerator()
+    
+type SpecWithValidationTests() =
+    let errorsReducer (validation, other) (v, o) =
+        Seq.append validation v,
+        Option.map2 (sprintf "%s\n%s") other o
+        |> Option.orElse other
+        |> Option.orElse o
+    let rec errInnerToResponse location err =
+        match err with
+        | SpecWithValidation.ArgumentValidationError res ->
+            seq {
+                for err in res do
+                    let v: SpecWithValidation.validationErrors =
+                        {
+                            location = location
+                            propertyPath = err.MemberNames |> Seq.toArray
+                            message = err.ErrorMessage
+                        }
+                    v
+            }, None
+        | SpecWithValidation.CombinedArgumentErrors combined ->
+            combined
+            |> Seq.map (errInnerToResponse location)
+            |> Seq.reduce errorsReducer
+        | _ -> Seq.empty, SpecWithValidation.argErrorToString 0 err |> Some
+    let rec errOuterToResponse err =
+        match err with
+            | SpecWithValidation.BodyBindingError inner -> errInnerToResponse "body" inner
+            | SpecWithValidation.PathBindingError inner -> errInnerToResponse "path" inner
+            | SpecWithValidation.QueryBindingError inner -> errInnerToResponse "query" inner
+            | SpecWithValidation.CombinedArgumentLocationError combined ->
+                combined
+                |> Seq.map errOuterToResponse
+                |> Seq.reduce errorsReducer
+    let errToResponse err =
+        let validation, other = errOuterToResponse err
+        let e: SpecWithValidation.validationErrorResponse =
+            {validationErrors = validation |> Seq.toArray
+             otherErrors = other}
+        e
+    let specWithValidationService=
+        {
+            new SpecWithValidation.Service() with
+                member _.TestValidationInput ((_, _, _)) =
+                    task {
+                        return Choice1Of2 "ok"
+                    }
+                member _.TestValidationInputError ((err, _)) =
+                    task {
+                        return Choice2Of2 (errToResponse err)
+                    }
+                
+        }
+        
+    let configureApp (app : IApplicationBuilder) =
+        app.UseGiraffe SpecWithValidation.webApp
+        
+    let jsonSettings =
+        JsonSerializerSettings(Converters=[|optionConverter|])
+
+    let configureServices (services : IServiceCollection) =
+        services
+            .AddGiraffe()
+            .AddSingleton<IJsonSerializer>(NewtonsoftJsonSerializer(jsonSettings))
+            .AddSingleton(specWithValidationService)
+        |> ignore
+
+    let configureLogging (loggerBuilder : ILoggingBuilder) =
+        loggerBuilder.AddFilter(fun lvl -> lvl.Equals LogLevel.Error)
+                     .AddConsole()
+                     .AddDebug() |> ignore
+
+    let webHostBuilder =
+        WebHost.CreateDefaultBuilder()
+            .Configure(Action<IApplicationBuilder> configureApp)
+            .ConfigureServices(configureServices)
+            .ConfigureLogging(configureLogging)
+            
+    let server = new TestServer(webHostBuilder)
+    let client = server.CreateClient()
+    
+    let toUrlString (path: SpecWithValidation.PostTestValidationPath, query: SpecWithValidation.PostTestValidationQuery) =
+        let query =
+            seq {
+                for prop in query.GetType().GetProperties(System.Reflection.BindingFlags.Public ||| System.Reflection.BindingFlags.Instance) do
+                    let value = prop.GetValue query
+                    if value <> null then
+                        sprintf "%s=%s" prop.Name (string value |> Uri.EscapeDataString)
+            } |> String.concat "&"
+        let pathStringParam = if isNull path.stringOfRestrictedToBeBetween3And8Length then "" else Uri.EscapeDataString path.stringOfRestrictedToBeBetween3And8Length
+        sprintf "/test-validation/%d/%s?%s" path.versionEnum pathStringParam query
+    let toContent (s: SpecWithValidation.TestValidationPostBodyJson) =
+            let json = JsonConvert.SerializeObject([|s|], jsonSettings)
+            let content = new StringContent(json, Encoding.UTF8, "application/json")
+            content
+    
+    [<Theory>]
+    [<ClassData(typeof<ValidCasesEnumerator>)>]
+    let ``Valid request -> 200 "ok"`` (description: string, body, pnq)  = task {
+        do ignore description
+        use content = toContent body
+        let url = toUrlString pnq
+        let! response = client.PostAsync(url, content)
+        let! responseText = response.Content.ReadAsStringAsync()
+        do Assert.Equal("\"ok\"", responseText)
+        do Assert.Equal(HttpStatusCode.OK, response.StatusCode)
+    }
+    
+    [<Theory>]
+    [<ClassData(typeof<InvalidCasesEnumerator>)>]
+    let ``Invalid request -> 400 "{json description}"`` (description: string, body, pnq, err) = task {
+        do ignore description
+        use content = toContent body
+        let url = toUrlString pnq
+        let! response = client.PostAsync(url, content)
+        let! responseText = response.Content.ReadAsStringAsync()
+        let responseJson = JsonConvert.DeserializeObject<SpecWithValidation.validationErrorResponse>(responseText, jsonSettings)
+        do Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
+        do Assert.Equal(err, responseJson)
+    }

--- a/tests/GiraffeGenerator.IntegrationTests/specs/specWithValidation.yaml
+++ b/tests/GiraffeGenerator.IntegrationTests/specs/specWithValidation.yaml
@@ -1,0 +1,402 @@
+openapi: "3.0.0"
+info:
+  title: Spec with validated arguments
+  version: 1
+paths:
+  /test-validation/{versionEnum}/{stringOfRestrictedToBeBetween3And8Length}:
+    parameters:
+      - name: versionEnum
+        in: path
+        required: true
+        schema:
+          type: integer
+          enum:
+            - 1
+            - 2
+            - 3
+      - name: stringOfRestrictedToBeBetween3And8Length
+        in: path
+        required: true
+        schema:
+          type: string
+          minLength: 3
+          maxLength: 8
+    post:
+      tags:
+        - search
+      summary: >-
+        Used to test validation
+      operationId: TestValidation
+      parameters:
+        - name: maxLengthRestrictedTo8String
+          schema:
+            type: string
+            maxLength: 8
+          in: query
+          required: true
+        - name: minLengthRestrictedTo3String
+          schema:
+            type: string
+            minLength: 3
+          in: query
+          required: true
+        - name: stringOfDDMMMPattern
+          schema:
+            type: string
+            pattern: ^((3[0-1])|([0-2]?[0-9]))(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov)$
+          in: query
+          required: true
+        - name: stringOfLengthBetween8And64ContainingAGiraffe
+          schema:
+            type: string
+            pattern: giraffe
+            minLength: 8
+            maxLength: 64
+          in: query
+          required: true
+        - name: integerDivisibleBy2
+          schema:
+            type: integer
+            multipleOf: 2
+          in: query
+          required: true
+        - name: integerBetween8And64
+          schema:
+            type: integer
+            minimum: 8
+            maximum: 64
+          in: query
+          required: true
+        - name: integerBetween8And64Exclusive
+          schema:
+            type: integer
+            minimum: 8
+            maximum: 64
+            exclusiveMaximum: true
+          in: query
+          required: true
+        - name: integerBetween8ExclusiveAnd64
+          schema:
+            type: integer
+            minimum: 8
+            exclusiveMinimum: true
+            maximum: 64
+          in: query
+          required: true
+        - name: integerBetween8ExclusiveAnd64Exclusive
+          schema:
+            type: integer
+            minimum: 8
+            exclusiveMinimum: true
+            maximum: 64
+            exclusiveMaximum: true
+          in: query
+          required: true
+        - name: integerGTE8
+          schema:
+            type: integer
+            minimum: 8
+          in: query
+          required: true
+        - name: integerGT8
+          schema:
+            type: integer
+            minimum: 8
+            exclusiveMinimum: true
+          in: query
+          required: true
+        - name: integerLTE64
+          schema:
+            type: integer
+            maximum: 64
+          in: query
+          required: true
+        - name: integerLT64
+          schema:
+            type: integer
+            maximum: 64
+            exclusiveMaximum: true
+          in: query
+          required: true
+        - name: integerEQ64
+          schema:
+            type: integer
+            minimum: 64
+            maximum: 64
+          in: query
+          required: true
+        - name: longEnum
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int64
+            enum:
+              - -9223372036854775808
+              - 0
+              - 9223372036854775807
+        - name: longDivisibleBy2
+          schema:
+            type: integer
+            format: int64
+            multipleOf: 2
+          in: query
+          required: true
+        - name: longBetween8And64
+          schema:
+            type: integer
+            format: int64
+            minimum: 8
+            maximum: 64
+          in: query
+          required: true
+        - name: longBetween8And64Exclusive
+          schema:
+            type: integer
+            format: int64
+            minimum: 8
+            maximum: 64
+            exclusiveMaximum: true
+          in: query
+          required: true
+        - name: longBetween8ExclusiveAnd64
+          schema:
+            type: integer
+            format: int64
+            minimum: 8
+            exclusiveMinimum: true
+            maximum: 64
+          in: query
+          required: true
+        - name: longBetween8ExclusiveAnd64Exclusive
+          schema:
+            type: integer
+            format: int64
+            minimum: 8
+            exclusiveMinimum: true
+            maximum: 64
+            exclusiveMaximum: true
+          in: query
+          required: true
+        - name: longGTE8
+          schema:
+            type: integer
+            format: int64
+            minimum: 8
+          in: query
+          required: true
+        - name: longGT8
+          schema:
+            type: integer
+            format: int64
+            minimum: 8
+            exclusiveMinimum: true
+          in: query
+          required: true
+        - name: longLTE64
+          schema:
+            type: integer
+            format: int64
+            maximum: 64
+          in: query
+          required: true
+        - name: longLT64
+          schema:
+            type: integer
+            format: int64
+            maximum: 64
+            exclusiveMaximum: true
+          in: query
+          required: true
+        - name: longEQ64
+          schema:
+            type: integer
+            format: int64
+            minimum: 64
+            maximum: 64
+          in: query
+          required: true
+        - name: floatEnum
+          in: query
+          required: true
+          schema:
+            type: number
+            enum:
+              - 3.14
+              - 3.141
+              - 3.1415
+              - 3.14159
+              - 3.141592
+        - name: floatBetween8And64
+          schema:
+            type: number
+            minimum: 8
+            maximum: 64
+          in: query
+          required: true
+        - name: floatBetween8And64Exclusive
+          schema:
+            type: number
+            minimum: 8
+            maximum: 64
+            exclusiveMaximum: true
+          in: query
+          required: true
+        - name: floatBetween8ExclusiveAnd64
+          schema:
+            type: number
+            minimum: 8
+            exclusiveMinimum: true
+            maximum: 64
+          in: query
+          required: true
+        - name: floatBetween8ExclusiveAnd64Exclusive
+          schema:
+            type: number
+            minimum: 8
+            exclusiveMinimum: true
+            maximum: 64
+            exclusiveMaximum: true
+          in: query
+          required: true
+        - name: floatGTE8
+          schema:
+            type: number
+            minimum: 8
+          in: query
+          required: true
+        - name: floatGT8
+          schema:
+            type: number
+            minimum: 8
+            exclusiveMinimum: true
+          in: query
+          required: true
+        - name: floatLTE64
+          schema:
+            type: number
+            maximum: 64
+          in: query
+          required: true
+        - name: floatLT64
+          schema:
+            type: number
+            maximum: 64
+            exclusiveMaximum: true
+          in: query
+          required: true
+        - name: floatEQ64
+          schema:
+            type: number
+            minimum: 64
+            maximum: 64
+          in: query
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              uniqueItems: true
+              items:
+                type: object
+                properties:
+                  arrayOf2To4UniqueItems:
+                    type: array
+                    uniqueItems: true
+                    minItems: 2
+                    maxItems: 4
+                    items:
+                      type: integer
+                  arrayOf2To4Items:
+                    type: array
+                    minItems: 2
+                    maxItems: 4
+                    items:
+                      type: integer
+                  arrayOptionOfMinimum2Items:
+                    type: array
+                    minItems: 2
+                    items:
+                      type: integer
+                  arrayOfMaximum4Items:
+                    type: array
+                    maxItems: 4
+                    items:
+                      type: integer
+                  nestedValidationArrayOfIntGTE2:
+                    type: array
+                    items:
+                      type: integer
+                      minimum: 2
+                  nestedValidationObjectOfIntGTE2:
+                    type: object
+                    properties:
+                      nestedIntGT2:
+                        type: integer
+                        minimum: 2
+                    required:
+                      - nestedIntGT2
+                  nestedValidationOptionOfIntGTE2:
+                    type: integer
+                    minimum: 2
+                  deeplyNestedValidation:
+                    type: array
+                    items:
+                      type: array
+                      uniqueItems: true
+                      maxItems: 2
+                      items:
+                        type: object
+                        properties:
+                          intGTE2ObjectOption:
+                            type: object
+                            properties:
+                              intGTE2Option:
+                                type: integer
+                                minimum: 2
+                required:
+                  - arrayOf2To4UniqueItems
+                  - arrayOf2To4Items
+                  - arrayOfMaximum4Items
+                  - nestedValidationArrayOfIntGTE2
+                  - nestedValidationObjectOfIntGTE2
+      responses:
+        '200':
+          description: object is valid
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: object is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/validationErrorResponse'
+components:
+  schemas:
+    validationErrorResponse:
+      type: object
+      properties:
+        validationErrors:
+          type: array
+          items:
+            type: object
+            properties:
+              location:
+                type: string
+              propertyPath:
+                type: array
+                items:
+                  type: string
+              message:
+                type: string
+            required:
+              - location
+              - propertyPath
+              - message
+        otherErrors:
+          type: string
+      required:
+        - validationErrors

--- a/tests/GiraffeGenerator.IntegrationTests/specs/specWithValidationExtensibility.yaml
+++ b/tests/GiraffeGenerator.IntegrationTests/specs/specWithValidationExtensibility.yaml
@@ -1,0 +1,32 @@
+openapi: "3.0.0"
+info:
+  title: Spec with a simple validated argument for extensibility testing
+  version: 1
+paths:
+  /test-validation:
+    get:
+      tags:
+        - search
+      summary: >-
+        Used to test validation
+      operationId: TestValidation
+      parameters:
+        - name: maxLengthRestrictedTo8String
+          schema:
+            type: string
+            maxLength: 8
+          in: query
+          required: true
+      responses:
+        '200':
+          description: object is valid
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: object is invalid
+          content:
+            application/json:
+              schema:
+                type: string


### PR DESCRIPTION
This PR introduces support for OpenAPI validation including
- multipleOf (for integer types)
- maximum
- exclusiveMaximum
- minimum
- exclusiveMinimum
- maxLength
- minLength
- maxItems
- minItems
- uniqueItems
- pattern (for strings without the format)
- enum (for numeric primitives and strings)

including validation of almost-arbitrary nested monads (nesting of arrays greater than 10 would fail the generation, but the limit may be easily extended. Also I've observed Fantomas being really slow for some deeply nested code during null-checking implementation attempts, may show up here as well).
The validation is based on System.ComponentModel.DataAnnotations with some augmentations (e.g. attributes for missing validation rules).
The most interesting augmentation is a custom recursive validator described and introduced in 3645660.